### PR TITLE
Customize landing page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,25 +4,43 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
+import { Button } from '@/components/ui/button';
+import { Logo } from '@/components/Logo';
 
 export default function HomePage() {
   const { isAuthenticated, isLoading } = useAuth();
   const router = useRouter();
 
   useEffect(() => {
-    if (!isLoading) {
-      if (isAuthenticated) {
-        router.replace('/dashboard');
-      } else {
-        router.replace('/login');
-      }
+    if (!isLoading && isAuthenticated) {
+      router.replace('/dashboard');
     }
   }, [isAuthenticated, isLoading, router]);
 
-  // Optional: Render a loading state or a blank page while redirecting
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p>Carregando PsiGuard...</p>
+      </div>
+    );
+  }
+
   return (
-    <div className="flex min-h-screen items-center justify-center">
-      <p>Carregando PsiGuard...</p>
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background p-4 text-center">
+      <Logo />
+      <h1 className="mt-6 text-3xl font-headline font-bold text-primary">Bem-vindo ao PsiGuard</h1>
+      <p className="mt-4 max-w-xl text-foreground">
+        Simplifique a gestão de pacientes e agendamentos em um ambiente seguro e prático.
+      </p>
+      <ul className="mt-6 space-y-1 text-muted-foreground text-sm">
+        <li>• Controle de usuários e permissões</li>
+        <li>• Prontuário eletrônico seguro</li>
+        <li>• Gerenciamento de agenda e lista de espera</li>
+      </ul>
+      <div className="mt-8 flex gap-4">
+        <Button onClick={() => router.push('/login')}>Entrar</Button>
+        <Button variant="outline" onClick={() => router.push('/register')}>Registrar</Button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- improve `page.tsx` to show a friendly landing page when not authenticated

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run typecheck` *(fails: duplicate identifier errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841e50fc4a08324a79eac7b3102fdf4