### PR TITLE
Implement notification system with bell icon

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import './globals.css';
 import { AuthProvider } from '@/contexts/AuthContext';
+import { NotificationProvider } from '@/contexts/NotificationContext';
 import { Toaster } from "@/components/ui/toaster";
 
 export const metadata: Metadata = {
@@ -22,8 +23,10 @@ export default function RootLayout({
       </head>
       <body className="font-body antialiased">
         <AuthProvider>
-          {children}
-          <Toaster />
+          <NotificationProvider>
+            {children}
+            <Toaster />
+          </NotificationProvider>
         </AuthProvider>
       </body>
     </html>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -4,6 +4,7 @@ import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 import { Button } from '@/components/ui/button';
 import { Menu } from 'lucide-react';
 import { AppSidebar } from './Sidebar'; // Import the new sidebar
+import { NotificationBell } from './NotificationBell';
 import { useAuth } from '@/contexts/AuthContext';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
@@ -51,7 +52,9 @@ export function AppHeader() {
           </SheetContent>
         </Sheet>
       </div>
-      
+
+      <NotificationBell />
+
       {user && (
          <DropdownMenu>
             <DropdownMenuTrigger asChild>

--- a/src/components/layout/NotificationBell.tsx
+++ b/src/components/layout/NotificationBell.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Bell } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from '@/components/ui/dropdown-menu';
+import { useNotifications } from '@/contexts/NotificationContext';
+
+export function NotificationBell() {
+  const { notifications, unreadCount, markAsRead, markAllAsRead } = useNotifications();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="relative h-10 w-10" data-ai-hint="notification bell">
+          <Bell className="h-5 w-5" />
+          {unreadCount > 0 && (
+            <span className="absolute top-0 right-0 inline-flex items-center justify-center px-1.5 py-0.5 text-[10px] font-bold leading-none text-white transform translate-x-1/2 -translate-y-1/2 bg-red-600 rounded-full">
+              {unreadCount}
+            </span>
+          )}
+          <span className="sr-only">Abrir notificações</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-72">
+        <DropdownMenuLabel className="flex justify-between items-center">
+          Notificações
+          {unreadCount > 0 && (
+            <button className="text-xs underline" onClick={markAllAsRead}>
+              Marcar todas como lidas
+            </button>
+          )}
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {notifications.length === 0 ? (
+          <DropdownMenuItem className="text-sm text-muted-foreground">
+            Nenhuma notificação
+          </DropdownMenuItem>
+        ) : (
+          notifications.map((n) => (
+            <DropdownMenuItem
+              key={n.id}
+              onSelect={() => markAsRead(n.id)}
+              className={n.read ? 'text-muted-foreground text-sm' : 'font-semibold text-sm'}
+            >
+              {n.message}
+            </DropdownMenuItem>
+          ))
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/contexts/NotificationContext.tsx
+++ b/src/contexts/NotificationContext.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { createContext, useContext, useState, ReactNode } from 'react';
+
+export interface Notification {
+  id: string;
+  message: string;
+  read: boolean;
+}
+
+interface NotificationContextType {
+  notifications: Notification[];
+  unreadCount: number;
+  markAsRead: (id: string) => void;
+  markAllAsRead: () => void;
+}
+
+const NotificationContext = createContext<NotificationContextType | undefined>(undefined);
+
+const defaultNotifications: Notification[] = [
+  { id: '1', message: 'Novo paciente adicionado \u00e0 lista de espera: Diana Prince', read: false },
+  { id: '2', message: 'Consulta amanh\u00e3 com Alice Wonderland \u00e0s 10:00', read: false },
+  { id: '3', message: 'Entre em contato com Clark Kent - aguardando h\u00e1 3 dias', read: false },
+  { id: '4', message: 'Revisar tarefas administrativas pendentes', read: false },
+];
+
+export const NotificationProvider = ({ children }: { children: ReactNode }) => {
+  const [notifications, setNotifications] = useState<Notification[]>(defaultNotifications);
+
+  const markAsRead = (id: string) => {
+    setNotifications((prev) => prev.map((n) => (n.id === id ? { ...n, read: true } : n)));
+  };
+
+  const markAllAsRead = () => {
+    setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+  };
+
+  const unreadCount = notifications.filter((n) => !n.read).length;
+
+  return (
+    <NotificationContext.Provider value={{ notifications, unreadCount, markAsRead, markAllAsRead }}>
+      {children}
+    </NotificationContext.Provider>
+  );
+};
+
+export const useNotifications = () => {
+  const context = useContext(NotificationContext);
+  if (context === undefined) {
+    throw new Error('useNotifications must be used within a NotificationProvider');
+  }
+  return context;
+};


### PR DESCRIPTION
## Summary
- add a Notification context with mock data and helpers
- create `NotificationBell` dropdown component
- include the notification bell in the header
- wrap app with `NotificationProvider`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_e_6841eea6b76483248ff9619aea59a5de