### PR TITLE
Add templates management area

### DIFF
--- a/src/app/(app)/templates/page.tsx
+++ b/src/app/(app)/templates/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState, useEffect } from 'react';
+import type { Template } from '@/lib/types';
+import { mockTemplates } from '@/lib/mock-data';
+import { TemplateTable } from '@/components/templates/TemplateTable';
+import { Button } from '@/components/ui/button';
+import { PlusCircle } from 'lucide-react';
+import { TemplateFormDialog } from '@/components/templates/TemplateFormDialog';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useToast } from '@/hooks/use-toast';
+
+export default function TemplatesPage() {
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    setTemplates(mockTemplates);
+  }, []);
+
+  const handleSave = (tpl: Template) => {
+    setTemplates(prev => {
+      const exists = prev.find(t => t.id === tpl.id);
+      if (exists) {
+        return prev.map(t => (t.id === tpl.id ? tpl : t));
+      }
+      return [...prev, tpl];
+    });
+  };
+
+  const handleDelete = (id: string) => {
+    setTemplates(prev => prev.filter(t => t.id !== id));
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold font-headline">Modelos</h1>
+          <p className="text-muted-foreground">Gerencie modelos reutilizáveis.</p>
+        </div>
+        <TemplateFormDialog onSave={handleSave} isOpen={isFormOpen} onOpenChange={setIsFormOpen}>
+          <Button onClick={() => setIsFormOpen(true)} className="shadow-md">
+            <PlusCircle className="mr-2 h-5 w-5" /> Novo Modelo
+          </Button>
+        </TemplateFormDialog>
+      </div>
+
+      <Card className="shadow-lg rounded-lg">
+        <CardHeader>
+          <CardTitle>Modelos Salvos</CardTitle>
+          <CardDescription>Total de {templates.length} modelos disponíveis.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <TemplateTable templates={templates} onSave={handleSave} onDelete={handleDelete} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
   Users,
   CalendarDays,
   ListChecks,
+  FileText,
   LogOut,
   Settings,
   PanelLeft,
@@ -33,6 +34,7 @@ const navItems = [
   { href: '/patients', label: 'Pacientes', icon: Users },
   { href: '/appointments', label: 'Agendamentos', icon: CalendarDays },
   { href: '/waiting-list', label: 'Lista de Espera', icon: ListChecks },
+  { href: '/templates', label: 'Modelos', icon: FileText },
   // { href: '/settings', label: 'Configurações', icon: Settings }, // Future
 ];
 

--- a/src/components/templates/TemplateFormDialog.tsx
+++ b/src/components/templates/TemplateFormDialog.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import * as z from "zod";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Loader2 } from "lucide-react";
+import type { Template, TemplateCategory } from "@/lib/types";
+import { useState, useEffect } from "react";
+
+const templateFormSchema = z.object({
+  name: z.string().min(2, { message: "Nome é obrigatório." }),
+  category: z.enum(["session-note", "email", "treatment-plan"]),
+  content: z.string().min(1, { message: "Conteúdo é obrigatório." }),
+});
+
+type TemplateFormValues = z.infer<typeof templateFormSchema>;
+
+interface TemplateFormDialogProps {
+  template?: Template | null;
+  onSave: (data: Template) => void;
+  children: React.ReactNode;
+  isOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export function TemplateFormDialog({
+  template,
+  onSave,
+  children,
+  isOpen: controlledIsOpen,
+  onOpenChange: controlledOnOpenChange,
+}: TemplateFormDialogProps) {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const isOpen = controlledIsOpen !== undefined ? controlledIsOpen : internalOpen;
+  const onOpenChange =
+    controlledOnOpenChange !== undefined ? controlledOnOpenChange : setInternalOpen;
+
+  const form = useForm<TemplateFormValues>({
+    resolver: zodResolver(templateFormSchema),
+    defaultValues: template
+      ? { name: template.name, category: template.category, content: template.content }
+      : { name: "", category: "session-note" as TemplateCategory, content: "" },
+  });
+
+  useEffect(() => {
+    if (template) {
+      form.reset({ name: template.name, category: template.category, content: template.content });
+    } else {
+      form.reset({ name: "", category: "session-note", content: "" });
+    }
+  }, [template, form, isOpen]);
+
+  async function onSubmit(values: TemplateFormValues) {
+    setIsLoading(true);
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    const templateData: Template = {
+      id: template?.id || `tpl-${Date.now()}`,
+      ...values,
+    };
+    onSave(templateData);
+    setIsLoading(false);
+    onOpenChange(false);
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="sm:max-w-md rounded-lg shadow-xl">
+        <DialogHeader>
+          <DialogTitle className="font-headline text-xl">
+            {template ? "Editar Modelo" : "Novo Modelo"}
+          </DialogTitle>
+          <DialogDescription>
+            {template ? "Atualize o modelo." : "Preencha os dados do novo modelo."}
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 py-4">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Nome do Modelo</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Título" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="category"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Categoria</FormLabel>
+                  <Select onValueChange={field.onChange} defaultValue={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Categoria" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="session-note">Nota de Sessão</SelectItem>
+                      <SelectItem value="email">Email</SelectItem>
+                      <SelectItem value="treatment-plan">Plano de Tratamento</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="content"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Conteúdo</FormLabel>
+                  <FormControl>
+                    <Textarea rows={6} placeholder="Digite o conteúdo do modelo" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter className="pt-4">
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isLoading}>
+                Cancelar
+              </Button>
+              <Button type="submit" disabled={isLoading}>
+                {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : template ? "Salvar" : "Criar"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/templates/TemplateTable.tsx
+++ b/src/components/templates/TemplateTable.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import type { Template } from "@/lib/types";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { FilePenLine, Trash2 } from "lucide-react";
+import { useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { useToast } from "@/hooks/use-toast";
+import { TemplateFormDialog } from "./TemplateFormDialog";
+
+interface TemplateTableProps {
+  templates: Template[];
+  onSave: (template: Template) => void;
+  onDelete: (templateId: string) => void;
+}
+
+export function TemplateTable({ templates, onSave, onDelete }: TemplateTableProps) {
+  const [editing, setEditing] = useState<Template | null>(null);
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const { toast } = useToast();
+
+  const handleEdit = (template: Template) => {
+    setEditing(template);
+    setIsFormOpen(true);
+  };
+
+  const handleSave = (tpl: Template) => {
+    onSave(tpl);
+    toast({
+      title: editing ? "Modelo Atualizado" : "Modelo Criado",
+      description: `O modelo ${tpl.name} foi salvo com sucesso.`,
+    });
+    setEditing(null);
+    setIsFormOpen(false);
+  };
+
+  const handleDelete = (id: string, name: string) => {
+    onDelete(id);
+    toast({
+      title: "Modelo Excluído",
+      description: `O modelo ${name} foi removido.`,
+      variant: "destructive",
+    });
+  };
+
+  return (
+    <>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Nome</TableHead>
+            <TableHead>Categoria</TableHead>
+            <TableHead className="text-right">Ações</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {templates.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={3} className="text-center h-24">
+                Nenhum modelo cadastrado.
+              </TableCell>
+            </TableRow>
+          )}
+          {templates.map((tpl) => (
+            <TableRow key={tpl.id} className="hover:bg-muted/50 transition-colors">
+              <TableCell className="font-medium">{tpl.name}</TableCell>
+              <TableCell>{tpl.category}</TableCell>
+              <TableCell className="text-right">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => handleEdit(tpl)}
+                  className="mr-2 text-blue-600 hover:text-blue-500"
+                >
+                  <FilePenLine className="h-4 w-4" />
+                  <span className="sr-only">Editar</span>
+                </Button>
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button variant="ghost" size="icon" className="text-destructive hover:text-destructive/80">
+                      <Trash2 className="h-4 w-4" />
+                      <span className="sr-only">Excluir</span>
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Confirmar Exclusão</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        Tem certeza que deseja excluir o modelo {tpl.name}?
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancelar</AlertDialogCancel>
+                      <AlertDialogAction onClick={() => handleDelete(tpl.id, tpl.name)} className="bg-destructive hover:bg-destructive/90">
+                        Excluir
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      <TemplateFormDialog
+        template={editing}
+        onSave={handleSave}
+        isOpen={isFormOpen && !!editing}
+        onOpenChange={(open) => {
+          setIsFormOpen(open);
+          if (!open) setEditing(null);
+        }}
+      >
+        <button className="hidden" />
+      </TemplateFormDialog>
+    </>
+  );
+}

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -4,6 +4,7 @@ import type {
   WaitingListItem,
   User,
   SessionNote,
+  Template,
 } from '@/lib/types';
 
 // 👤 Usuário mock
@@ -164,4 +165,20 @@ export const mockWaitingList: WaitingListItem[] = [
     addedDate: new Date(today.setDate(today.getDate() - 3)).toISOString(),
     notes: 'Encaminhamento urgente do Dr. Hamilton.',
   },
+];
+
+// 📑 Modelos de texto reutilizáveis
+export const mockTemplates: Template[] = [
+  {
+    id: 'tpl-001',
+    name: 'Nota de Sessão Padrão',
+    category: 'session-note',
+    content: 'Paciente apresentou progresso desde a última sessão...'
+  },
+  {
+    id: 'tpl-002',
+    name: 'Email de Lembrete',
+    category: 'email',
+    content: 'Olá {{nome}}, este é um lembrete do seu próximo agendamento...'
+  }
 ];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -50,5 +50,18 @@ export interface WaitingListItem {
   notes?: string;
 }
 
+// 📑 Modelo reutilizável (anotação, email, plano de tratamento, etc.)
+export type TemplateCategory =
+  | 'session-note'
+  | 'email'
+  | 'treatment-plan';
+
+export interface Template {
+  id: string;
+  name: string;
+  category: TemplateCategory;
+  content: string;
+}
+
 // 🔄 Tipo utilitário: paciente parcial para formulários e updates
 export type PartialPatient = Partial<Patient>;


### PR DESCRIPTION
## Summary
- add Template and TemplateCategory types
- add mock template data
- add TemplateFormDialog and TemplateTable components
- create templates management page
- link Templates section in sidebar

## Testing
- `npm run typecheck` *(fails: Cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6841ef3c0c0483249c04b4ad70f1b51a