### PR TITLE
Fix stray newlines

### DIFF
--- a/src/components/appointments/AppointmentFormDialog.tsx
+++ b/src/components/appointments/AppointmentFormDialog.tsx
@@ -1,4 +1,3 @@
-
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,4 +1,3 @@
-
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";

--- a/src/components/patients/PatientFormDialog.tsx
+++ b/src/components/patients/PatientFormDialog.tsx
@@ -1,4 +1,3 @@
-
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";

--- a/src/components/patients/PatientTable.tsx
+++ b/src/components/patients/PatientTable.tsx
@@ -1,4 +1,3 @@
-
 "use client";
 
 import type { Patient } from "@/lib/types";

--- a/src/components/waitlist/AddToWaitlistDialog.tsx
+++ b/src/components/waitlist/AddToWaitlistDialog.tsx
@@ -1,4 +1,3 @@
-
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";

--- a/src/components/waitlist/WaitlistTable.tsx
+++ b/src/components/waitlist/WaitlistTable.tsx
@@ -1,4 +1,3 @@
-
 "use client";
 
 import type { WaitingListItem } from "@/lib/types";


### PR DESCRIPTION
## Summary
- remove blank lines before `"use client"` in components

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: TypeScript errors in AIInsightsSection)*

------
https://chatgpt.com/codex/tasks/task_e_6841e04b0e1c8324ab4e4b006bc44685