### PR TITLE
Fix patient helper import

### DIFF
--- a/src/components/patients/PatientDetailsClient.tsx
+++ b/src/components/patients/PatientDetailsClient.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import type { Patient, SessionNote } from "@/lib/types"; // Import the types
-import { mockPatients } from "@/lib/mock-data"; // For finding the patient
+import { getMockPatientById } from "@/lib/mock-data"; // For finding the patient
 import { useState, useEffect } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";


### PR DESCRIPTION
## Summary
- fix import for mocked patient data fetcher in `PatientDetailsClient`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: JSX element has no closing tag)*

------
https://chatgpt.com/codex/tasks/task_e_6841a38ae3f4832495e37170e8c46687