### PR TITLE
Add knowledge base feature

### DIFF
--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -9,6 +9,7 @@
 - Session Notifications: Automated email reminders for upcoming sessions (24 hours and 30 minutes before).
 - Waiting List: Functionality to add patients to a waiting list and move them to available time slots.
 - AI-Driven Session Insights: After session notes have been written, analyze notes and historical session data, using a tool to surface contextualized warnings or concerns within the patient record.
+- Internal Knowledge Base: Professionals can store personal study notes, references and useful links, with optional Google Drive integration.
 
 ## Style Guidelines:
 

--- a/src/app/(app)/knowledge-base/page.tsx
+++ b/src/app/(app)/knowledge-base/page.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState, useEffect } from 'react';
+import type { KnowledgeBaseItem } from '@/lib/types';
+import { mockKnowledgeBase } from '@/lib/mock-data';
+import { KnowledgeBaseTable } from '@/components/knowledge-base/KnowledgeBaseTable';
+import { KnowledgeFormDialog } from '@/components/knowledge-base/KnowledgeFormDialog';
+import { Button } from '@/components/ui/button';
+import { PlusCircle } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useToast } from "@/hooks/use-toast";
+
+export default function KnowledgeBasePage() {
+  const [items, setItems] = useState<KnowledgeBaseItem[]>([]);
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    setItems(mockKnowledgeBase);
+  }, []);
+
+  const handleAddItem = (item: KnowledgeBaseItem) => {
+    setItems(prev => [...prev, item]);
+    toast({
+      title: "Nota Salva",
+      description: `"${item.title}" foi adicionada à base de conhecimento.`,
+    });
+    setIsFormOpen(false);
+  };
+
+  const handleDeleteItem = (itemId: string) => {
+    setItems(prev => prev.filter(i => i.id !== itemId));
+    toast({
+      title: "Nota Removida",
+      description: `Item removido com sucesso.`,
+      variant: "destructive",
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold font-headline">Base de Conhecimento</h1>
+          <p className="text-muted-foreground">Notas pessoais e referências úteis.</p>
+        </div>
+        <KnowledgeFormDialog onSave={handleAddItem} isOpen={isFormOpen} onOpenChange={setIsFormOpen}>
+          <Button onClick={() => setIsFormOpen(true)} className="shadow-md">
+            <PlusCircle className="mr-2 h-5 w-5" />
+            Nova Nota
+          </Button>
+        </KnowledgeFormDialog>
+      </div>
+
+      <Card className="shadow-lg rounded-lg">
+        <CardHeader>
+          <CardTitle>Notas Salvas</CardTitle>
+          <CardDescription>Total de {items.length} notas.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <KnowledgeBaseTable items={items} onDeleteItem={handleDeleteItem} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/knowledge-base/KnowledgeBaseTable.tsx
+++ b/src/components/knowledge-base/KnowledgeBaseTable.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import type { KnowledgeBaseItem } from "@/lib/types";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Trash2, ExternalLink } from "lucide-react";
+import { format, parseISO } from "date-fns";
+import { ptBR } from "date-fns/locale";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import Link from "next/link";
+
+interface KnowledgeBaseTableProps {
+  items: KnowledgeBaseItem[];
+  onDeleteItem: (itemId: string) => void;
+}
+
+export function KnowledgeBaseTable({ items, onDeleteItem }: KnowledgeBaseTableProps) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Título</TableHead>
+          <TableHead>Link</TableHead>
+          <TableHead>Data</TableHead>
+          <TableHead className="text-right">Ações</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {items.length === 0 && (
+          <TableRow>
+            <TableCell colSpan={4} className="text-center h-24">
+              Nenhuma nota adicionada.
+            </TableCell>
+          </TableRow>
+        )}
+        {items.map((item) => (
+          <TableRow key={item.id} className="hover:bg-muted/50 transition-colors">
+            <TableCell className="font-medium max-w-xs truncate">{item.title}</TableCell>
+            <TableCell>
+              {item.link ? (
+                <Link href={item.link} target="_blank" rel="noopener noreferrer" className="flex items-center gap-1 text-primary hover:underline">
+                  <ExternalLink className="h-4 w-4" />
+                  Abrir
+                </Link>
+              ) : (
+                "-"
+              )}
+            </TableCell>
+            <TableCell>{format(parseISO(item.createdDate), "dd/MM/yyyy", { locale: ptBR })}</TableCell>
+            <TableCell className="text-right">
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button variant="ghost" size="icon" className="text-destructive hover:text-destructive/80">
+                    <Trash2 className="h-4 w-4" />
+                    <span className="sr-only">Excluir</span>
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Confirmar Exclusão</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      Tem certeza que deseja remover "{item.title}"?
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancelar</AlertDialogCancel>
+                    <AlertDialogAction onClick={() => onDeleteItem(item.id)} className="bg-destructive hover:bg-destructive/90">
+                      Excluir
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/src/components/knowledge-base/KnowledgeFormDialog.tsx
+++ b/src/components/knowledge-base/KnowledgeFormDialog.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import * as z from "zod";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Loader2 } from "lucide-react";
+import type { KnowledgeBaseItem } from "@/lib/types";
+import { useState } from "react";
+
+const knowledgeFormSchema = z.object({
+  title: z.string().min(2, { message: "Título é obrigatório." }),
+  description: z.string().min(2, { message: "Descrição é obrigatória." }),
+  link: z.string().url({ message: "Link inválido." }).optional().or(z.literal("")),
+});
+
+type KnowledgeFormValues = z.infer<typeof knowledgeFormSchema>;
+
+interface KnowledgeFormDialogProps {
+  item?: KnowledgeBaseItem | null;
+  onSave: (data: KnowledgeBaseItem) => void;
+  children: React.ReactNode;
+  isOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export function KnowledgeFormDialog({ item, onSave, children, isOpen: controlledIsOpen, onOpenChange: controlledOnOpenChange }: KnowledgeFormDialogProps) {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const isOpen = controlledIsOpen !== undefined ? controlledIsOpen : internalOpen;
+  const onOpenChange = controlledOnOpenChange !== undefined ? controlledOnOpenChange : setInternalOpen;
+
+  const form = useForm<KnowledgeFormValues>({
+    resolver: zodResolver(knowledgeFormSchema),
+    defaultValues: item ? { ...item, link: item.link || "" } : { title: "", description: "", link: "" },
+  });
+
+  function resetForm() {
+    form.reset(item ? { ...item, link: item.link || "" } : { title: "", description: "", link: "" });
+  }
+
+  async function onSubmit(values: KnowledgeFormValues) {
+    setIsLoading(true);
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    const newItem: KnowledgeBaseItem = {
+      id: item?.id || `kb-${Date.now()}`,
+      title: values.title,
+      description: values.description,
+      link: values.link || undefined,
+      createdDate: item?.createdDate || new Date().toISOString(),
+    };
+    onSave(newItem);
+    setIsLoading(false);
+    onOpenChange(false);
+    resetForm();
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="sm:max-w-md rounded-lg shadow-xl">
+        <DialogHeader>
+          <DialogTitle className="font-headline text-xl">{item ? "Editar Nota" : "Nova Nota"}</DialogTitle>
+          <DialogDescription>
+            {item ? "Atualize sua nota." : "Adicione uma nova referência ou anotação."}
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 py-4">
+            <FormField
+              control={form.control}
+              name="title"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Título</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Título da nota" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Descrição</FormLabel>
+                  <FormControl>
+                    <Textarea placeholder="Conteúdo ou resumo" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="link"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Link (opcional)</FormLabel>
+                  <FormControl>
+                    <Input placeholder="https://" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button type="submit" disabled={isLoading} className="w-full">
+                {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Salvar
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
   Users,
   CalendarDays,
   ListChecks,
+  BookOpen,
   LogOut,
   Settings,
   PanelLeft,
@@ -33,6 +34,7 @@ const navItems = [
   { href: '/patients', label: 'Pacientes', icon: Users },
   { href: '/appointments', label: 'Agendamentos', icon: CalendarDays },
   { href: '/waiting-list', label: 'Lista de Espera', icon: ListChecks },
+  { href: '/knowledge-base', label: 'Base de Conhecimento', icon: BookOpen },
   // { href: '/settings', label: 'Configurações', icon: Settings }, // Future
 ];
 

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -2,6 +2,7 @@ import type {
   Patient,
   Appointment,
   WaitingListItem,
+  KnowledgeBaseItem,
   User,
   SessionNote,
 } from '@/lib/types';
@@ -163,5 +164,22 @@ export const mockWaitingList: WaitingListItem[] = [
     contact: 'clark@example.com',
     addedDate: new Date(today.setDate(today.getDate() - 3)).toISOString(),
     notes: 'Encaminhamento urgente do Dr. Hamilton.',
+  },
+];
+
+// 📚 Base de conhecimento mock
+export const mockKnowledgeBase: KnowledgeBaseItem[] = [
+  {
+    id: 'kb-001',
+    title: 'Abordagens Terapêuticas Cognitivas',
+    description: 'Resumo das principais técnicas de TCC.',
+    link: 'https://drive.google.com/example-tcc',
+    createdDate: new Date(today).toISOString(),
+  },
+  {
+    id: 'kb-002',
+    title: 'Leituras sobre Mindfulness',
+    description: 'Links úteis e artigos recomendados.',
+    createdDate: new Date(today).toISOString(),
   },
 ];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -50,5 +50,14 @@ export interface WaitingListItem {
   notes?: string;
 }
 
+// 📚 Item da base de conhecimento interna
+export interface KnowledgeBaseItem {
+  id: string;
+  title: string;
+  description: string;
+  link?: string; // Pode ser um link do Google Drive ou referência externa
+  createdDate: string; // ISO 8601
+}
+
 // 🔄 Tipo utilitário: paciente parcial para formulários e updates
 export type PartialPatient = Partial<Patient>;


### PR DESCRIPTION
## Summary
- add internal knowledge base bullet to the blueprint
- create types and mock data for knowledge base notes
- add a Knowledge Base page with table and dialog components
- include navigation entry in the sidebar

## Testing
- `npm install`
- `npm run typecheck`
- `npm run lint` *(fails: asks to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_6841efe776188324be0f44f833fb4eb7