### PR TITLE
Add system-wide settings page

### DIFF
--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { SettingsForm } from "@/components/settings/SettingsForm";
+
+export default function SettingsPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold font-headline">Configurações</h1>
+        <p className="text-muted-foreground">Ajuste preferências que afetam todo o sistema.</p>
+      </div>
+      <SettingsForm />
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import './globals.css';
 import { AuthProvider } from '@/contexts/AuthContext';
+import { SettingsProvider } from '@/contexts/SettingsContext';
 import { Toaster } from "@/components/ui/toaster";
 
 export const metadata: Metadata = {
@@ -22,8 +23,10 @@ export default function RootLayout({
       </head>
       <body className="font-body antialiased">
         <AuthProvider>
-          {children}
-          <Toaster />
+          <SettingsProvider>
+            {children}
+            <Toaster />
+          </SettingsProvider>
         </AuthProvider>
       </body>
     </html>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -33,7 +33,7 @@ const navItems = [
   { href: '/patients', label: 'Pacientes', icon: Users },
   { href: '/appointments', label: 'Agendamentos', icon: CalendarDays },
   { href: '/waiting-list', label: 'Lista de Espera', icon: ListChecks },
-  // { href: '/settings', label: 'Configurações', icon: Settings }, // Future
+  { href: '/settings', label: 'Configurações', icon: Settings },
 ];
 
 export function AppSidebar() {

--- a/src/components/settings/SettingsForm.tsx
+++ b/src/components/settings/SettingsForm.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import * as z from "zod";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { useSettings } from "@/contexts/SettingsContext";
+import { useToast } from "@/hooks/use-toast";
+import { useEffect } from "react";
+
+const settingsFormSchema = z.object({
+  clinicName: z.string().min(1, "Nome da clínica é obrigatório."),
+  clinicContact: z.string().min(1, "Contato é obrigatório."),
+  startHour: z.string().regex(/^([01]\d|2[0-3]):([0-5]\d)$/, "Hora inválida."),
+  endHour: z.string().regex(/^([01]\d|2[0-3]):([0-5]\d)$/, "Hora inválida."),
+  defaultSessionDuration: z.coerce.number().int().positive(),
+  externalIntegration: z.string().optional(),
+});
+
+type SettingsFormValues = z.infer<typeof settingsFormSchema>;
+
+export function SettingsForm() {
+  const { settings, updateSettings } = useSettings();
+  const { toast } = useToast();
+
+  const form = useForm<SettingsFormValues>({
+    resolver: zodResolver(settingsFormSchema),
+    defaultValues: settings,
+  });
+
+  useEffect(() => {
+    form.reset(settings);
+  }, [settings, form]);
+
+  const onSubmit = (values: SettingsFormValues) => {
+    updateSettings(values);
+    toast({
+      title: "Configurações Salvas",
+      description: "As configurações foram atualizadas com sucesso.",
+    });
+  };
+
+  return (
+    <Card className="shadow-lg rounded-lg">
+      <CardHeader>
+        <CardTitle>Configurações Globais</CardTitle>
+        <CardDescription>Defina as preferências gerais do sistema.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="clinicName"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Nome da Clínica</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="clinicContact"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Contato da Clínica</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="startHour"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Horário Inicial</FormLabel>
+                    <FormControl>
+                      <Input type="time" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="endHour"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Horário Final</FormLabel>
+                    <FormControl>
+                      <Input type="time" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <FormField
+              control={form.control}
+              name="defaultSessionDuration"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Duração Padrão da Sessão (min)</FormLabel>
+                  <FormControl>
+                    <Input type="number" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="externalIntegration"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Integração Externa (URL)</FormLabel>
+                  <FormControl>
+                    <Input {...field} placeholder="https://service.com/api" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="pt-2">
+              <Button type="submit">Salvar Configurações</Button>
+            </div>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useState } from "react";
+import type { SystemSettings } from "@/lib/types";
+import { mockSystemSettings } from "@/lib/mock-data";
+
+interface SettingsContextType {
+  settings: SystemSettings;
+  updateSettings: (settings: SystemSettings) => void;
+}
+
+const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
+
+export const SettingsProvider = ({ children }: { children: React.ReactNode }) => {
+  const [settings, setSettings] = useState<SystemSettings>(mockSystemSettings);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("psiguard_settings");
+    if (stored) {
+      try {
+        setSettings(JSON.parse(stored));
+      } catch {
+        // ignore parse errors and use defaults
+      }
+    }
+  }, []);
+
+  const updateSettings = (newSettings: SystemSettings) => {
+    setSettings(newSettings);
+    localStorage.setItem("psiguard_settings", JSON.stringify(newSettings));
+  };
+
+  return (
+    <SettingsContext.Provider value={{ settings, updateSettings }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+};
+
+export const useSettings = () => {
+  const context = useContext(SettingsContext);
+  if (context === undefined) {
+    throw new Error("useSettings must be used within a SettingsProvider");
+  }
+  return context;
+};

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -4,6 +4,7 @@ import type {
   WaitingListItem,
   User,
   SessionNote,
+  SystemSettings,
 } from '@/lib/types';
 
 // 👤 Usuário mock
@@ -165,3 +166,13 @@ export const mockWaitingList: WaitingListItem[] = [
     notes: 'Encaminhamento urgente do Dr. Hamilton.',
   },
 ];
+
+// ⚙️ Configurações padrão do sistema
+export const mockSystemSettings: SystemSettings = {
+  clinicName: 'Clínica Exemplo',
+  clinicContact: 'contato@exemplo.com',
+  startHour: '09:00',
+  endHour: '17:00',
+  defaultSessionDuration: 50,
+  externalIntegration: '',
+};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -52,3 +52,13 @@ export interface WaitingListItem {
 
 // 🔄 Tipo utilitário: paciente parcial para formulários e updates
 export type PartialPatient = Partial<Patient>;
+
+// ⚙️ Configurações globais do sistema
+export interface SystemSettings {
+  clinicName: string;
+  clinicContact: string;
+  startHour: string; // HH:MM
+  endHour: string;   // HH:MM
+  defaultSessionDuration: number;
+  externalIntegration?: string;
+}


### PR DESCRIPTION
## Summary
- add `SystemSettings` type and mock default settings
- create `SettingsContext` for global preferences
- wrap app with `SettingsProvider`
- implement settings form and page
- expose settings link in sidebar

## Testing
- `npm run build`
- `npm run lint` *(fails: prompts for config)*
- `npm run typecheck` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841ef8230b48324b97406efe5267d13