### PR TITLE
Add settings and knowledge base features

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { useAuth } from '@/contexts/AuthContext';
+import { useSettings } from '@/contexts/SettingsContext';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
@@ -10,6 +11,7 @@ import Image from 'next/image';
 
 export default function DashboardPage() {
   const { user } = useAuth();
+  const { dashboard } = useSettings();
 
   if (!user) return null; // Or a loading state
 
@@ -36,6 +38,7 @@ export default function DashboardPage() {
       </div>
 
       <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {dashboard.showAppointments && (
         <Card className="shadow-lg hover:shadow-xl transition-shadow">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Próximos Agendamentos</CardTitle>
@@ -49,7 +52,9 @@ export default function DashboardPage() {
             </Button>
           </CardContent>
         </Card>
+        )}
 
+        {dashboard.showPatients && (
         <Card className="shadow-lg hover:shadow-xl transition-shadow">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Pacientes Ativos</CardTitle>
@@ -63,7 +68,9 @@ export default function DashboardPage() {
             </Button>
           </CardContent>
         </Card>
+        )}
 
+        {dashboard.showWaitingList && (
         <Card className="shadow-lg hover:shadow-xl transition-shadow">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Lista de Espera</CardTitle>
@@ -77,6 +84,7 @@ export default function DashboardPage() {
             </Button>
           </CardContent>
         </Card>
+        )}
       </div>
 
       <Card className="shadow-lg">

--- a/src/app/(app)/knowledge-base/page.tsx
+++ b/src/app/(app)/knowledge-base/page.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useState } from 'react';
+
+interface Article {
+  id: string;
+  question: string;
+  answer: string;
+}
+
+const articles: Article[] = [
+  { id: '1', question: 'Como adicionar um paciente?', answer: 'Vá para a página de pacientes e clique em "Adicionar Paciente".' },
+  { id: '2', question: 'Posso personalizar as métricas do dashboard?', answer: 'Sim, utilize a página de configurações para escolher quais métricas deseja ver.' },
+  { id: '3', question: 'Os dados são criptografados?', answer: 'Este protótipo usa criptografia apenas em campos selecionados. Veja a documentação para mais detalhes.' },
+];
+
+export default function KnowledgeBasePage() {
+  const [selected, setSelected] = useState<Article | null>(null);
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold font-headline">Base de Conhecimento</h1>
+      <div className="grid gap-4 md:grid-cols-2">
+        {articles.map((a) => (
+          <Card key={a.id} onClick={() => setSelected(a)} className="cursor-pointer hover:shadow-md">
+            <CardHeader>
+              <CardTitle>{a.question}</CardTitle>
+            </CardHeader>
+          </Card>
+        ))}
+      </div>
+      {selected && (
+        <Card className="max-w-2xl">
+          <CardHeader>
+            <CardTitle>{selected.question}</CardTitle>
+            <CardDescription>Resposta</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p>{selected.answer}</p>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/patients/page.tsx
+++ b/src/app/(app)/patients/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from 'react';
 import type { Patient } from '@/lib/types';
-import { mockPatients } from '@/lib/mock-data'; // ✅ corrigido aqui
 import { getMockPatientsList, updateMockPatient } from '@/lib/mock-data';
 import { PatientTable } from '@/components/patients/PatientTable';
 import { Button } from '@/components/ui/button';
@@ -17,9 +16,8 @@ export default function PatientsPage() {
   const { toast } = useToast();
 
   useEffect(() => {
+    // Carrega lista de pacientes de exemplo
     setPatients(getMockPatientsList());
-    // ✅ agora usando mockPatients direto
-    setPatients(mockPatients);
   }, []);
 
   const handleAddOrUpdatePatient = (patientData: Patient) => {
@@ -87,7 +85,7 @@ export default function PatientsPage() {
         </CardHeader>
         <CardContent>
           <PatientTable
-            patients={getMockPatientsList()}
+            patients={patients}
             onUpdatePatient={handleAddOrUpdatePatient}
             onDeletePatient={handleDeletePatient}
           />

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useSettings } from '@/contexts/SettingsContext';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+
+export default function SettingsPage() {
+  const { dashboard, updateDashboard } = useSettings();
+
+  const handleChange = (key: keyof typeof dashboard) => (checked: boolean) => {
+    updateDashboard({ [key]: checked });
+  };
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold font-headline">Configurações</h1>
+      <Card className="shadow-lg max-w-md">
+        <CardHeader>
+          <CardTitle>Métricas do Dashboard</CardTitle>
+          <CardDescription>Escolha quais cartões de métrica deseja exibir.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <label className="flex items-center gap-2">
+            <Checkbox checked={dashboard.showAppointments} onCheckedChange={handleChange('showAppointments')} />
+            Mostrar agendamentos futuros
+          </label>
+          <label className="flex items-center gap-2">
+            <Checkbox checked={dashboard.showPatients} onCheckedChange={handleChange('showPatients')} />
+            Mostrar pacientes ativos
+          </label>
+          <label className="flex items-center gap-2">
+            <Checkbox checked={dashboard.showWaitingList} onCheckedChange={handleChange('showWaitingList')} />
+            Mostrar lista de espera
+          </label>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -32,7 +32,7 @@ const mockRegisterUser = async (
 export default function RegisterPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [role, setRole] = useState('psicologo'); // Default role
+  const [role, setRole] = useState('Psicólogo'); // Default role matches UserRole
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState(false);
@@ -93,7 +93,7 @@ export default function RegisterPage() {
                 <SelectValue placeholder="Selecione o tipo de usuário" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="psicologo">Psicólogo</SelectItem>
+              <SelectItem value="Psicólogo">Psicólogo</SelectItem>
                 {/* Add other roles as needed in the future */}
                 {/* <SelectItem value="admin_global">Admin Global</SelectItem> */}
                 {/* <SelectItem value="admin_secretario">Admin/Secretário</SelectItem> */}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import './globals.css';
 import { AuthProvider } from '@/contexts/AuthContext';
 import { NotificationProvider } from '@/contexts/NotificationContext';
+import { SettingsProvider } from '@/contexts/SettingsContext';
 import { Toaster } from "@/components/ui/toaster";
 
 export const metadata: Metadata = {
@@ -23,10 +24,12 @@ export default function RootLayout({
       </head>
       <body className="font-body antialiased">
         <AuthProvider>
-          <NotificationProvider>
-            {children}
-            <Toaster />
-          </NotificationProvider>
+          <SettingsProvider>
+            <NotificationProvider>
+              {children}
+              <Toaster />
+            </NotificationProvider>
+          </SettingsProvider>
         </AuthProvider>
       </body>
     </html>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -75,7 +75,10 @@ export function AppHeader() {
                 </div>
               </DropdownMenuLabel>
               <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={() => router.push('/settings')}> {/* Placeholder */}
+              <DropdownMenuItem onClick={() => router.push('/knowledge-base')}>
+                Base de Conhecimento
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => router.push('/settings')}>
                 Configurações
               </DropdownMenuItem>
               <DropdownMenuSeparator />

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   LogOut,
   Settings,
   PanelLeft,
+  BookOpenCheck,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/contexts/AuthContext';
@@ -35,7 +36,8 @@ const navItems = [
   { href: '/appointments', label: 'Agendamentos', icon: CalendarDays },
   { href: '/waiting-list', label: 'Lista de Espera', icon: ListChecks },
   { href: '/templates', label: 'Modelos', icon: FileText },
-  // { href: '/settings', label: 'Configurações', icon: Settings }, // Future
+  { href: '/knowledge-base', label: 'Base de Conhecimento', icon: BookOpenCheck },
+  { href: '/settings', label: 'Configurações', icon: Settings },
 ];
 
 export function AppSidebar() {

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+
+export interface DashboardSettings {
+  showAppointments: boolean;
+  showPatients: boolean;
+  showWaitingList: boolean;
+}
+
+interface SettingsContextType {
+  dashboard: DashboardSettings;
+  updateDashboard: (settings: Partial<DashboardSettings>) => void;
+}
+
+const defaultDashboard: DashboardSettings = {
+  showAppointments: true,
+  showPatients: true,
+  showWaitingList: true,
+};
+
+const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
+
+export const SettingsProvider = ({ children }: { children: ReactNode }) => {
+  const [dashboard, setDashboard] = useState<DashboardSettings>(defaultDashboard);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('psiguard_dashboard_settings');
+    if (stored) {
+      try {
+        setDashboard(JSON.parse(stored));
+      } catch (_) {
+        // ignore parse errors
+      }
+    }
+  }, []);
+
+  const updateDashboard = (settings: Partial<DashboardSettings>) => {
+    setDashboard((prev) => {
+      const updated = { ...prev, ...settings };
+      localStorage.setItem('psiguard_dashboard_settings', JSON.stringify(updated));
+      return updated;
+    });
+  };
+
+  return (
+    <SettingsContext.Provider value={{ dashboard, updateDashboard }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+};
+
+export const useSettings = () => {
+  const context = useContext(SettingsContext);
+  if (context === undefined) {
+    throw new Error('useSettings must be used within a SettingsProvider');
+  }
+  return context;
+};


### PR DESCRIPTION
## Summary
- add SettingsContext and wrap root layout
- add system-wide settings page with dashboard metric toggles
- add knowledge base page
- make dashboard metrics configurable via settings
- add links in sidebar and header
- fix patient page state initialization and registration role mismatch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841f488156883248bad91d4074d87f6