### PR TITLE
Import patient helper from mock data

### DIFF
--- a/src/components/patients/PatientDetailsClient.tsx
+++ b/src/components/patients/PatientDetailsClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { Patient, SessionNote } from "@/lib/types";
-import { mockPatients } from "@/lib/mock-data"; // mockPatients agora está exportado corretamente
+import { getMockPatientById } from "@/lib/mock-data";
 import { useState, useEffect } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -17,10 +17,6 @@ interface PatientDetailsClientProps {
   patientId: string;
 }
 
-// ✅ Corrigido: tipando o parâmetro 'p'
-const getMockPatientById = (id: string): Patient | null => {
-  return mockPatients.find((p: Patient) => p.id === id) || null;
-};
 
 export function PatientDetailsClient({ patientId }: PatientDetailsClientProps) {
   const [patient, setPatient] = useState<Patient | null>(null);

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -109,6 +109,18 @@ export const updateMockPatient = (updatedPatient: Patient): Patient => {
   return updatedPatient;
 };
 
+// 🔍 Busca paciente pelo ID
+export const getMockPatientById = (id: string): Patient | null => {
+  const patient = mockPatients.find((p) => p.id === id);
+  if (!patient) return null;
+  return {
+    ...patient,
+    name: decryptMock(patient.name),
+    contact: decryptMock(patient.contact),
+    dateOfBirth: decryptMock(patient.dateOfBirth),
+  };
+};
+
 // 📆 Agendamentos mock
 export const mockAppointments: Appointment[] = [
   {


### PR DESCRIPTION
## Summary
- expose `getMockPatientById` from mock-data utilities
- use `getMockPatientById` inside `PatientDetailsClient`

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run typecheck` *(fails: JSX element has no corresponding closing tag)*

------
https://chatgpt.com/codex/tasks/task_e_6841e028aa748324a3865077f01dad5e