### PR TITLE
Add mock knowledge base feature

### DIFF
--- a/src/app/(app)/knowledge-base/page.tsx
+++ b/src/app/(app)/knowledge-base/page.tsx
@@ -2,27 +2,17 @@
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useState } from 'react';
-
-interface Article {
-  id: string;
-  question: string;
-  answer: string;
-}
-
-const articles: Article[] = [
-  { id: '1', question: 'Como adicionar um paciente?', answer: 'Vá para a página de pacientes e clique em "Adicionar Paciente".' },
-  { id: '2', question: 'Posso personalizar as métricas do dashboard?', answer: 'Sim, utilize a página de configurações para escolher quais métricas deseja ver.' },
-  { id: '3', question: 'Os dados são criptografados?', answer: 'Este protótipo usa criptografia apenas em campos selecionados. Veja a documentação para mais detalhes.' },
-];
+import { KnowledgeBaseArticle } from '@/lib/types';
+import { mockKnowledgeBaseArticles } from '@/lib/mock-data';
 
 export default function KnowledgeBasePage() {
-  const [selected, setSelected] = useState<Article | null>(null);
+  const [selected, setSelected] = useState<KnowledgeBaseArticle | null>(null);
 
   return (
     <div className="space-y-6">
       <h1 className="text-3xl font-bold font-headline">Base de Conhecimento</h1>
       <div className="grid gap-4 md:grid-cols-2">
-        {articles.map((a) => (
+        {mockKnowledgeBaseArticles.map((a) => (
           <Card key={a.id} onClick={() => setSelected(a)} className="cursor-pointer hover:shadow-md">
             <CardHeader>
               <CardTitle>{a.question}</CardTitle>

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -5,6 +5,7 @@ import type {
   User,
   SessionNote,
   Template,
+  KnowledgeBaseArticle,
 } from '@/lib/types';
 
 // 👤 Usuário mock
@@ -192,5 +193,26 @@ export const mockTemplates: Template[] = [
     name: 'Email de Lembrete',
     category: 'email',
     content: 'Olá {{nome}}, este é um lembrete do seu próximo agendamento...'
+  }
+];
+
+// 📚 Artigos da base de conhecimento
+export const mockKnowledgeBaseArticles: KnowledgeBaseArticle[] = [
+  {
+    id: 'kb-001',
+    question: 'Como adicionar um paciente?',
+    answer: 'Vá para a página de pacientes e clique em "Adicionar Paciente".'
+  },
+  {
+    id: 'kb-002',
+    question: 'Posso personalizar as métricas do dashboard?',
+    answer:
+      'Sim, utilize a página de configurações para escolher quais métricas deseja ver.'
+  },
+  {
+    id: 'kb-003',
+    question: 'Os dados são criptografados?',
+    answer:
+      'Este protótipo usa criptografia apenas em campos selecionados. Veja a documentação para mais detalhes.'
   }
 ];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -63,5 +63,12 @@ export interface Template {
   content: string;
 }
 
+// 📚 Artigo da base de conhecimento
+export interface KnowledgeBaseArticle {
+  id: string;
+  question: string;
+  answer: string;
+}
+
 // 🔄 Tipo utilitário: paciente parcial para formulários e updates
 export type PartialPatient = Partial<Patient>;


### PR DESCRIPTION
## Summary
- define `KnowledgeBaseArticle` type
- add mock knowledge base articles
- display knowledge base articles from mock data

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841ff735c188324a346006bb6c79c12