### PR TITLE
Add dated session note form

### DIFF
--- a/src/components/patients/PatientDetailsClient.tsx
+++ b/src/components/patients/PatientDetailsClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { Patient, SessionNote } from "@/lib/types";
-import { getMockPatientById } from "@/lib/mock-data";
+import { getMockPatientById, updateMockPatient } from "@/lib/mock-data";
 import { useState, useEffect } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -31,12 +31,16 @@ export function PatientDetailsClient({ patientId }: PatientDetailsClientProps) {
     setIsLoading(false);
   }, [patientId]);
 
-  const handleAddNote = async (id: string, noteContent: string) => {
+  const handleAddNote = async (
+    id: string,
+    noteContent: string,
+    noteDate: string
+  ) => {
     if (!patient) return;
 
     const newNote: SessionNote = {
       id: `sn-${Date.now()}`,
-      date: new Date().toISOString(),
+      date: noteDate,
       notes: noteContent,
     };
 
@@ -44,10 +48,12 @@ export function PatientDetailsClient({ patientId }: PatientDetailsClientProps) {
 
     setPatient(prev => {
       if (!prev) return null;
-      return {
+      const updated = {
         ...prev,
         sessionNotes: [...prev.sessionNotes, newNote],
       };
+      updateMockPatient(updated);
+      return updated;
     });
 
     toast({
@@ -56,16 +62,17 @@ export function PatientDetailsClient({ patientId }: PatientDetailsClientProps) {
     });
   };
 
-  // ✅ Corrigido: adicionada função para deletar nota
-  const handleDeleteNote = async (noteId: string) => {
+  const handleDeleteNote = async (id: string, noteId: string) => {
     if (!patient) return;
 
     setPatient(prev => {
       if (!prev) return null;
-      return {
+      const updated = {
         ...prev,
         sessionNotes: prev.sessionNotes.filter(note => note.id !== noteId),
       };
+      updateMockPatient(updated);
+      return updated;
     });
 
     toast({

--- a/src/components/patients/SessionNotesSection.tsx
+++ b/src/components/patients/SessionNotesSection.tsx
@@ -4,6 +4,7 @@ import type { SessionNote, Patient } from "@/lib/types";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import { Input } from "@/components/ui/input";
 import {
   Card,
   CardContent,
@@ -18,8 +19,12 @@ import { Separator } from "@/components/ui/separator";
 
 interface SessionNotesSectionProps {
   patient: Patient;
-  onAddNote: (patientId: string, noteContent: string) => Promise<void>;
-  onDeleteNote: (patientId: string, noteId: string) => Promise<void>; // ✅ incluído corretamente
+  onAddNote: (
+    patientId: string,
+    noteContent: string,
+    noteDate: string
+  ) => Promise<void>;
+  onDeleteNote: (patientId: string, noteId: string) => Promise<void>;
 }
 
 export function SessionNotesSection({
@@ -28,6 +33,9 @@ export function SessionNotesSection({
   onDeleteNote, // ✅ recebido nas props
 }: SessionNotesSectionProps) {
   const [newNote, setNewNote] = useState("");
+  const [newNoteDate, setNewNoteDate] = useState(
+    () => new Date().toISOString().slice(0, 16)
+  );
   const [showAddNoteForm, setShowAddNoteForm] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
 
@@ -35,8 +43,9 @@ export function SessionNotesSection({
     if (newNote.trim() === "") return;
     setIsSaving(true);
     try {
-      await onAddNote(patient.id, newNote);
+      await onAddNote(patient.id, newNote, newNoteDate);
       setNewNote("");
+      setNewNoteDate(new Date().toISOString().slice(0, 16));
       setShowAddNoteForm(false);
     } catch (error) {
       console.error("Failed to save note:", error);
@@ -75,6 +84,12 @@ export function SessionNotesSection({
               onChange={(e) => setNewNote(e.target.value)}
               rows={5}
               className="mb-3 text-base"
+            />
+            <Input
+              type="datetime-local"
+              value={newNoteDate}
+              onChange={(e) => setNewNoteDate(e.target.value)}
+              className="mb-3"
             />
             <div className="flex justify-end gap-2">
               <Button


### PR DESCRIPTION
## Summary
- add date input field for session notes
- persist added and removed notes in mock data
- adjust handlers to accept patientId, note content and date

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68420391d39c8324b75ace5b48c3b8de