### PR TITLE
Implement patient editing form on details page

### DIFF
--- a/src/components/patients/PatientDetailsClient.tsx
+++ b/src/components/patients/PatientDetailsClient.tsx
@@ -9,6 +9,7 @@ import { ArrowLeft, UserCircle, CalendarDays as CalendarIcon, Phone, Gift } from
 import Link from "next/link";
 import { SessionNotesSection } from "./SessionNotesSection";
 import { AIInsightsSection } from "./AIInsightsSection";
+import { PatientFormDialog } from "./PatientFormDialog";
 import { format, parseISO, differenceInYears } from "date-fns";
 import { useToast } from "@/hooks/use-toast";
 import Image from "next/image";
@@ -81,6 +82,15 @@ export function PatientDetailsClient({ patientId }: PatientDetailsClientProps) {
     });
   };
 
+  const handleSavePatient = (updatedPatient: Patient) => {
+    setPatient(updatedPatient);
+    updateMockPatient(updatedPatient);
+    toast({
+      title: "Paciente Atualizado",
+      description: "Os dados do paciente foram salvos com sucesso.",
+    });
+  };
+
   if (isLoading) {
     return (
       <div className="flex justify-center items-center h-64">
@@ -102,11 +112,16 @@ export function PatientDetailsClient({ patientId }: PatientDetailsClientProps) {
 
   return (
     <div className="space-y-6">
-      <Button asChild variant="outline" className="mb-6 shadow-sm">
-        <Link href="/patients">
-          <ArrowLeft className="mr-2 h-4 w-4" /> Voltar para Pacientes
-        </Link>
-      </Button>
+      <div className="flex items-center justify-between mb-6">
+        <Button asChild variant="outline" className="shadow-sm">
+          <Link href="/patients">
+            <ArrowLeft className="mr-2 h-4 w-4" /> Voltar para Pacientes
+          </Link>
+        </Button>
+        <PatientFormDialog patient={patient} onSave={handleSavePatient}>
+          <Button variant="default">Editar</Button>
+        </PatientFormDialog>
+      </div>
 
       <Card className="shadow-xl rounded-lg overflow-hidden">
         <div className="md:flex">


### PR DESCRIPTION
## Summary
- enable editing a patient's data directly from the patient details page
- update patient info in the mock datastore and UI

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68420526b0048324ad67bdafc38f7a6a