### PR TITLE
Add aggregated analytics page

### DIFF
--- a/src/app/(app)/analytics/page.tsx
+++ b/src/app/(app)/analytics/page.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { BarChart, Bar, XAxis, YAxis, Tooltip, PieChart, Pie, Cell, Legend } from 'recharts';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { mockAppointments, mockPatients } from '@/lib/mock-data';
+import { getWeeklySessionCounts, getProblemTypeCounts } from '@/lib/analytics';
+
+const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff8042', '#8dd1e1'];
+
+export default function AnalyticsPage() {
+  const weekly = getWeeklySessionCounts(mockAppointments);
+  const problems = Object.entries(getProblemTypeCounts(mockPatients)).map(([type, count]) => ({ type, count }));
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold font-headline">Tendências Agregadas</h1>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Sessões por Semana</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <BarChart width={400} height={300} data={weekly} className="mx-auto">
+            <XAxis dataKey="week" />
+            <YAxis allowDecimals={false} />
+            <Tooltip />
+            <Bar dataKey="count" fill="#8884d8" />
+          </BarChart>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Problemas Mais Comuns</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <PieChart width={400} height={300} className="mx-auto">
+            <Pie data={problems} dataKey="count" nameKey="type" outerRadius={100}>
+              {problems.map((_, i) => (
+                <Cell key={i} fill={COLORS[i % COLORS.length]} />
+              ))}
+            </Pie>
+            <Tooltip />
+            <Legend />
+          </PieChart>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   PanelLeft,
   BookOpenCheck,
   HeartPulse,
+  LineChart,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/contexts/AuthContext';
@@ -33,6 +34,7 @@ import {
 
 const navItems = [
   { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
+  { href: '/analytics', label: 'Tendências', icon: LineChart },
   { href: '/patients', label: 'Pacientes', icon: Users },
   { href: '/appointments', label: 'Agendamentos', icon: CalendarDays },
   { href: '/waiting-list', label: 'Lista de Espera', icon: ListChecks },

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,46 @@
+import { Appointment, Patient } from './types';
+import { startOfWeek, format } from 'date-fns';
+
+export function getWeeklySessionCounts(appointments: Appointment[]): { week: string; count: number }[] {
+  const counts: Record<string, number> = {};
+
+  for (const appt of appointments) {
+    const weekStart = startOfWeek(new Date(appt.dateTime), { weekStartsOn: 1 });
+    const key = format(weekStart, 'yyyy-MM-dd');
+    counts[key] = (counts[key] || 0) + 1;
+  }
+
+  return Object.entries(counts)
+    .map(([week, count]) => ({ week, count }))
+    .sort((a, b) => a.week.localeCompare(b.week));
+}
+
+const PROBLEM_KEYWORDS: Record<string, string[]> = {
+  ansiedade: ['ansiedade'],
+  ajustamento: ['ajustamento'],
+};
+
+export function getProblemTypeCounts(patients: Patient[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+
+  for (const patient of patients) {
+    for (const note of patient.sessionNotes) {
+      const text = note.notes.toLowerCase();
+      let matched = false;
+
+      for (const [type, keywords] of Object.entries(PROBLEM_KEYWORDS)) {
+        if (keywords.some((k) => text.includes(k))) {
+          counts[type] = (counts[type] || 0) + 1;
+          matched = true;
+          break;
+        }
+      }
+
+      if (!matched) {
+        counts.outros = (counts.outros || 0) + 1;
+      }
+    }
+  }
+
+  return counts;
+}


### PR DESCRIPTION
## Summary
- compute weekly session counts and common problems
- display aggregated trends in new analytics page
- link analytics page from sidebar navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684206cb73708324bab8a096d7e82126