### PR TITLE
Add medication quick reference list

### DIFF
--- a/src/app/(app)/medications/page.tsx
+++ b/src/app/(app)/medications/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { mockMedications } from "@/lib/mock-data";
+import type { Medication } from "@/lib/types";
+
+export default function MedicationsPage() {
+  const [search, setSearch] = useState("");
+
+  const filtered = mockMedications.filter((m: Medication) =>
+    (m.name + m.class + m.indications + m.sideEffects)
+      .toLowerCase()
+      .includes(search.toLowerCase())
+  );
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold font-headline">Medicamentos</h1>
+        <p className="text-muted-foreground">Lista de referência rápida.</p>
+      </div>
+      <Input
+        placeholder="Buscar..."
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        className="max-w-sm"
+      />
+      <div className="grid gap-4 md:grid-cols-2">
+        {filtered.map((m) => (
+          <Card key={m.id} className="hover:shadow-md">
+            <CardHeader>
+              <CardTitle>{m.name}</CardTitle>
+              <CardDescription>{m.class}</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <p>
+                <strong>Indicações:</strong> {m.indications}
+              </p>
+              <p>
+                <strong>Efeitos colaterais:</strong> {m.sideEffects}
+              </p>
+            </CardContent>
+          </Card>
+        ))}
+        {filtered.length === 0 && (
+          <p className="text-sm text-muted-foreground">Nenhum medicamento encontrado.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -75,6 +75,9 @@ export function AppHeader() {
                 </div>
               </DropdownMenuLabel>
               <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => router.push('/medications')}>
+                Medicamentos
+              </DropdownMenuItem>
               <DropdownMenuItem onClick={() => router.push('/knowledge-base')}>
                 Base de Conhecimento
               </DropdownMenuItem>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -14,6 +14,7 @@ import {
   BookOpenCheck,
   HeartPulse,
   LineChart,
+  Pill,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/contexts/AuthContext';
@@ -40,6 +41,7 @@ const navItems = [
   { href: '/waiting-list', label: 'Lista de Espera', icon: ListChecks },
   { href: '/templates', label: 'Modelos', icon: FileText },
   { href: '/self-care', label: 'Saúde Mental', icon: HeartPulse },
+  { href: '/medications', label: 'Medicamentos', icon: Pill },
   { href: '/knowledge-base', label: 'Base de Conhecimento', icon: BookOpenCheck },
   { href: '/settings', label: 'Configurações', icon: Settings },
 ];

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -7,6 +7,7 @@ import type {
   Template,
   KnowledgeBaseArticle,
   FinanceRecord,
+  Medication,
 } from '@/lib/types';
 
 // 👤 Usuário mock
@@ -243,5 +244,37 @@ export const mockKnowledgeBaseArticles: KnowledgeBaseArticle[] = [
     question: 'Os dados são criptografados?',
     answer:
       'Este protótipo usa criptografia apenas em campos selecionados. Veja a documentação para mais detalhes.'
+  }
+];
+
+// 💊 Lista de medicamentos comuns para referência rápida
+export const mockMedications: Medication[] = [
+  {
+    id: 'med-001',
+    name: 'Sertralina',
+    class: 'ISRS',
+    indications: 'Depressão, transtorno de ansiedade',
+    sideEffects: 'Náusea, insônia, boca seca'
+  },
+  {
+    id: 'med-002',
+    name: 'Fluoxetina',
+    class: 'ISRS',
+    indications: 'Depressão, transtorno obsessivo-compulsivo',
+    sideEffects: 'Agitação, dor de cabeça, insônia'
+  },
+  {
+    id: 'med-003',
+    name: 'Bupropiona',
+    class: 'Antidepressivo atípico',
+    indications: 'Depressão maior, cessação do tabagismo',
+    sideEffects: 'Boca seca, insônia, tremores'
+  },
+  {
+    id: 'med-004',
+    name: 'Clonazepam',
+    class: 'Benzodiazepínico',
+    indications: 'Transtorno de ansiedade, crises convulsivas',
+    sideEffects: 'Sedação, tontura, dependência'
   }
 ];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -78,6 +78,15 @@ export interface FinanceRecord {
   description?: string;
 }
 
+// 💊 Medicamento de referência rápida
+export interface Medication {
+  id: string;
+  name: string;
+  class: string;
+  indications: string;
+  sideEffects: string;
+}
+
 // 📋 Metadados de um inventário/teste
 export interface TestMeta {
   id: string;


### PR DESCRIPTION
## Summary
- add `Medication` interface
- provide mock medications
- show medications page with searchable list
- update navigation and header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68420fe16aa083249c2d0beae96ef056