### PR TITLE
Add basic schedule occupancy report

### DIFF
--- a/src/app/(app)/analytics/page.tsx
+++ b/src/app/(app)/analytics/page.tsx
@@ -2,14 +2,45 @@
 
 import { BarChart, Bar, XAxis, YAxis, Tooltip, PieChart, Pie, Cell, Legend } from 'recharts';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
 import { mockAppointments, mockPatients } from '@/lib/mock-data';
-import { getWeeklySessionCounts, getProblemTypeCounts } from '@/lib/analytics';
+import { getWeeklySessionCounts, getProblemTypeCounts, getScheduleOccupancy } from '@/lib/analytics';
+import { startOfWeek, endOfWeek, startOfMonth, endOfMonth } from 'date-fns';
+import { useState } from 'react';
+import { useSettings } from '@/contexts/SettingsContext';
 
 const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff8042', '#8dd1e1'];
 
 export default function AnalyticsPage() {
+  const { system } = useSettings();
+  const [period, setPeriod] = useState<'week' | 'month'>('week');
+
   const weekly = getWeeklySessionCounts(mockAppointments);
   const problems = Object.entries(getProblemTypeCounts(mockPatients)).map(([type, count]) => ({ type, count }));
+
+  const now = new Date();
+  const periodStart = period === 'week'
+    ? startOfWeek(now, { weekStartsOn: 1 })
+    : startOfMonth(now);
+  const periodEnd = period === 'week'
+    ? endOfWeek(now, { weekStartsOn: 1 })
+    : endOfMonth(now);
+
+  const occupancy = getScheduleOccupancy(
+    mockAppointments,
+    periodStart,
+    periodEnd,
+    system.workHoursStart,
+    system.workHoursEnd
+  );
+
+  const occupancyData = [
+    {
+      name: 'Ocupação',
+      Agendado: Number(occupancy.scheduledPercent.toFixed(2)),
+      Livre: Number(occupancy.freePercent.toFixed(2)),
+    },
+  ];
 
   return (
     <div className="space-y-6">
@@ -25,6 +56,30 @@ export default function AnalyticsPage() {
             <YAxis allowDecimals={false} />
             <Tooltip />
             <Bar dataKey="count" fill="#8884d8" />
+          </BarChart>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-col gap-2">
+          <CardTitle>Ocupação da Agenda</CardTitle>
+          <Select value={period} onValueChange={(v) => setPeriod(v as 'week' | 'month')}>
+            <SelectTrigger className="w-32">
+              <SelectValue placeholder="Período" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="week">Semana Atual</SelectItem>
+              <SelectItem value="month">Mês Atual</SelectItem>
+            </SelectContent>
+          </Select>
+        </CardHeader>
+        <CardContent>
+          <BarChart width={400} height={300} data={occupancyData} className="mx-auto">
+            <XAxis dataKey="name" />
+            <YAxis domain={[0, 100]} tickFormatter={(v) => `${v}%`} />
+            <Tooltip formatter={(v: number) => `${v}%`} />
+            <Bar dataKey="Agendado" stackId="a" fill="#8884d8" />
+            <Bar dataKey="Livre" stackId="a" fill="#82ca9d" />
           </BarChart>
         </CardContent>
       </Card>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,5 +1,11 @@
 import { Appointment, Patient } from './types';
-import { startOfWeek, format } from 'date-fns';
+import {
+  startOfWeek,
+  format,
+  parseISO,
+  addDays,
+  differenceInMinutes,
+} from 'date-fns';
 
 export function getWeeklySessionCounts(appointments: Appointment[]): { week: string; count: number }[] {
   const counts: Record<string, number> = {};
@@ -43,4 +49,51 @@ export function getProblemTypeCounts(patients: Patient[]): Record<string, number
   }
 
   return counts;
+}
+
+export interface OccupancyData {
+  scheduledMinutes: number;
+  freeMinutes: number;
+  scheduledPercent: number;
+  freePercent: number;
+}
+
+export function getScheduleOccupancy(
+  appointments: Appointment[],
+  start: Date,
+  end: Date,
+  workHoursStart = '09:00',
+  workHoursEnd = '17:00'
+): OccupancyData {
+  const [sh, sm] = workHoursStart.split(':').map(Number);
+  const [eh, em] = workHoursEnd.split(':').map(Number);
+  const dailyMinutes = differenceInMinutes(
+    new Date(0, 0, 0, eh, em),
+    new Date(0, 0, 0, sh, sm)
+  );
+
+  let totalAvailable = 0;
+  for (let d = new Date(start); d <= end; d = addDays(d, 1)) {
+    totalAvailable += dailyMinutes;
+  }
+
+  const scheduled = appointments
+    .filter((a) => {
+      const dt = parseISO(a.dateTime);
+      return dt >= start && dt <= end;
+    })
+    .reduce((sum, a) => sum + a.durationMinutes, 0);
+
+  const free = Math.max(totalAvailable - scheduled, 0);
+  const scheduledPercent = totalAvailable
+    ? (scheduled / totalAvailable) * 100
+    : 0;
+  const freePercent = 100 - scheduledPercent;
+
+  return {
+    scheduledMinutes: scheduled,
+    freeMinutes: free,
+    scheduledPercent,
+    freePercent,
+  };
 }


### PR DESCRIPTION
## Summary
- add occupancy calculation to analytics utils
- show schedule occupancy chart on analytics page

## Testing
- `npx jest` *(fails: Preset ts-jest not found)*
- `npm run typecheck` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68420f7a59e08324bef9fb0e95ae44cc