### PR TITLE
Add more psychiatric medications

### DIFF
--- a/src/app/(app)/medications/page.tsx
+++ b/src/app/(app)/medications/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { mockMedications } from "@/lib/mock-data";
+import type { Medication } from "@/lib/types";
+
+export default function MedicationsPage() {
+  const [search, setSearch] = useState("");
+
+  const filtered = mockMedications.filter((m: Medication) =>
+    (m.name + m.class + m.indications + m.sideEffects)
+      .toLowerCase()
+      .includes(search.toLowerCase())
+  );
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold font-headline">Medicamentos</h1>
+        <p className="text-muted-foreground">Lista de referência rápida.</p>
+      </div>
+      <Input
+        placeholder="Buscar..."
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        className="max-w-sm"
+      />
+      <div className="grid gap-4 md:grid-cols-2">
+        {filtered.map((m) => (
+          <Card key={m.id} className="hover:shadow-md">
+            <CardHeader>
+              <CardTitle>{m.name}</CardTitle>
+              <CardDescription>{m.class}</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <p>
+                <strong>Indicações:</strong> {m.indications}
+              </p>
+              <p>
+                <strong>Efeitos colaterais:</strong> {m.sideEffects}
+              </p>
+            </CardContent>
+          </Card>
+        ))}
+        {filtered.length === 0 && (
+          <p className="text-sm text-muted-foreground">Nenhum medicamento encontrado.</p>
+        )}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Informações meramente educativas. Para prescrição e orientações, consulte um
+        profissional de saúde.
+      </p>
+    </div>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -75,6 +75,9 @@ export function AppHeader() {
                 </div>
               </DropdownMenuLabel>
               <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => router.push('/medications')}>
+                Medicamentos
+              </DropdownMenuItem>
               <DropdownMenuItem onClick={() => router.push('/knowledge-base')}>
                 Base de Conhecimento
               </DropdownMenuItem>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -14,6 +14,7 @@ import {
   BookOpenCheck,
   HeartPulse,
   LineChart,
+  Pill,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/contexts/AuthContext';
@@ -40,6 +41,7 @@ const navItems = [
   { href: '/waiting-list', label: 'Lista de Espera', icon: ListChecks },
   { href: '/templates', label: 'Modelos', icon: FileText },
   { href: '/self-care', label: 'Saúde Mental', icon: HeartPulse },
+  { href: '/medications', label: 'Medicamentos', icon: Pill },
   { href: '/knowledge-base', label: 'Base de Conhecimento', icon: BookOpenCheck },
   { href: '/settings', label: 'Configurações', icon: Settings },
 ];

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -7,6 +7,7 @@ import type {
   Template,
   KnowledgeBaseArticle,
   FinanceRecord,
+  Medication,
 } from '@/lib/types';
 
 // 👤 Usuário mock
@@ -243,5 +244,87 @@ export const mockKnowledgeBaseArticles: KnowledgeBaseArticle[] = [
     question: 'Os dados são criptografados?',
     answer:
       'Este protótipo usa criptografia apenas em campos selecionados. Veja a documentação para mais detalhes.'
+  }
+];
+
+// 💊 Lista de medicamentos comuns para referência rápida
+export const mockMedications: Medication[] = [
+  {
+    id: 'med-001',
+    name: 'Sertralina',
+    class: 'ISRS',
+    indications:
+      'Depressão maior, transtorno de ansiedade generalizada e outros transtornos de humor',
+    sideEffects: 'Náusea, insônia, diminuição da libido, boca seca'
+  },
+  {
+    id: 'med-002',
+    name: 'Fluoxetina',
+    class: 'ISRS',
+    indications:
+      'Depressão, transtorno obsessivo-compulsivo e bulimia nervosa',
+    sideEffects:
+      'Agitação, dor de cabeça, distúrbios gastrointestinais, insônia'
+  },
+  {
+    id: 'med-003',
+    name: 'Bupropiona',
+    class: 'Antidepressivo atípico',
+    indications: 'Episódios depressivos e auxílio na cessação do tabagismo',
+    sideEffects:
+      'Boca seca, insônia, tremores, risco de convulsões em altas doses'
+  },
+  {
+    id: 'med-004',
+    name: 'Clonazepam',
+    class: 'Benzodiazepínico',
+    indications: 'Crises de ansiedade aguda e epilepsia',
+    sideEffects:
+      'Sedação, tontura, risco de dependência e comprometimento cognitivo'
+  },
+  {
+    id: 'med-005',
+    name: 'Diazepam',
+    class: 'Benzodiazepínico',
+    indications: 'Ansiedade, espasmos musculares e sintomas de abstinência alcoólica',
+    sideEffects: 'Sedação, confusão mental, potencial de dependência'
+  },
+  {
+    id: 'med-006',
+    name: 'Risperidona',
+    class: 'Antipsicótico atípico',
+    indications: 'Esquizofrenia, transtorno bipolar e irritabilidade no autismo',
+    sideEffects: 'Ganho de peso, sonolência, rigidez muscular'
+  },
+  {
+    id: 'med-007',
+    name: 'Olanzapina',
+    class: 'Antipsicótico atípico',
+    indications: 'Esquizofrenia e episódios maníacos do transtorno bipolar',
+    sideEffects: 'Sedação, ganho de peso, alterações metabólicas'
+  },
+  {
+    id: 'med-008',
+    name: 'Carbonato de Lítio',
+    class: 'Estabilizador de humor',
+    indications:
+      'Tratamento e prevenção de episódios maníacos e depressivos no transtorno bipolar',
+    sideEffects: 'Tremores, sede excessiva, problemas de tireoide'
+  },
+  {
+    id: 'med-009',
+    name: 'Quetiapina',
+    class: 'Antipsicótico atípico',
+    indications:
+      'Tratamento de sintomas da esquizofrenia, episódios de mania e depressão no transtorno bipolar',
+    sideEffects: 'Sonolência intensa, ganho de peso, boca seca'
+  },
+  {
+    id: 'med-010',
+    name: 'Haloperidol',
+    class: 'Antipsicótico típico',
+    indications:
+      'Controle de sintomas psicóticos agudos e manejo de agitação severa',
+    sideEffects: 'Rigidez muscular, inquietação, efeitos extrapiramidais'
   }
 ];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -78,6 +78,15 @@ export interface FinanceRecord {
   description?: string;
 }
 
+// 💊 Medicamento de referência rápida
+export interface Medication {
+  id: string;
+  name: string;
+  class: string;
+  indications: string;
+  sideEffects: string;
+}
+
 // 📋 Metadados de um inventário/teste
 export interface TestMeta {
   id: string;


### PR DESCRIPTION
## Summary
- expand descriptions for existing medications
- add Diazepam, Risperidona, Olanzapina and Carbonato de Lítio
- show medications in a new `/medications` page
- add disclaimers and extra medications (Quetiapina and Haloperidol)

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68420fe16aa083249c2d0beae96ef056