### PR TITLE
Address security concerns

### DIFF
--- a/docs/assessments-module.md
+++ b/docs/assessments-module.md
@@ -9,7 +9,7 @@
 
 ## Deploy
 
-1. Configure variáveis em `.env.local` e `.env` para chaves do Firebase, SendGrid e Twilio (`SENDGRID_API_KEY`, `SENDGRID_FROM_EMAIL`, `TWILIO_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_WHATSAPP_FROM`, `ASSESSMENT_TOKEN_SECRET`).
+1. Configure variáveis em `.env.local` e `.env` para chaves do Firebase, SendGrid e Twilio (`SENDGRID_API_KEY`, `SENDGRID_FROM_EMAIL`, `TWILIO_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_WHATSAPP_FROM`, `ASSESSMENT_TOKEN_SECRET`, `CRYPTO_SECRET_KEY`).
 2. Execute `npm install` para instalar dependências.
 3. Inicie os emuladores com `firebase emulators:start` para testes locais.
 4. Para deploy, rode `firebase deploy --only functions,firestore`.

--- a/firebase.json
+++ b/firebase.json
@@ -2,6 +2,9 @@
   "functions": {
     "source": "functions"
   },
+  "firestore": {
+    "rules": "docs/firestore.rules"
+  },
   "emulators": {
     "apphosting": {
       "port": 5002,

--- a/functions/sendAssessmentLink.ts
+++ b/functions/sendAssessmentLink.ts
@@ -9,7 +9,10 @@ const db = admin.firestore();
 
 sgMail.setApiKey(process.env.SENDGRID_API_KEY as string);
 const twilioClient = twilio(process.env.TWILIO_SID as string, process.env.TWILIO_AUTH_TOKEN as string);
-const TOKEN_SECRET = process.env.ASSESSMENT_TOKEN_SECRET as string;
+const TOKEN_SECRET = process.env.ASSESSMENT_TOKEN_SECRET;
+if (!TOKEN_SECRET) {
+  throw new Error('ASSESSMENT_TOKEN_SECRET environment variable is required');
+}
 
 function signToken(data: { patientId: string; assessmentId: string }) {
   return jwt.sign(data, TOKEN_SECRET, { expiresIn: '7d' });

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,10 +3,10 @@ import type {NextConfig} from 'next';
 const nextConfig: NextConfig = {
   /* config options here */
   typescript: {
-    ignoreBuildErrors: true,
+    ignoreBuildErrors: false,
   },
   eslint: {
-    ignoreDuringBuilds: true,
+    ignoreDuringBuilds: false,
   },
   images: {
     remotePatterns: [

--- a/src/lib/firebaseAdmin.ts
+++ b/src/lib/firebaseAdmin.ts
@@ -14,7 +14,10 @@ if (!getApps().length) {
 export const adminDb = getFirestore(app);
 export const adminAuth = getAuth(app);
 
-const TOKEN_SECRET = process.env.ASSESSMENT_TOKEN_SECRET || 'secret';
+const TOKEN_SECRET = process.env.ASSESSMENT_TOKEN_SECRET;
+if (!TOKEN_SECRET) {
+  throw new Error('ASSESSMENT_TOKEN_SECRET environment variable is required');
+}
 
 export function signAssessmentToken(payload: { assessmentId: string; patientId: string }): string {
   return jwt.sign(payload, TOKEN_SECRET, { expiresIn: '7d' });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,8 +1,11 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
-import CryptoJS from 'crypto-js'; // Assuming you have crypto-js installed
+import CryptoJS from 'crypto-js';
 
-const SECRET_KEY = process.env.NEXT_PUBLIC_CRYPTO_SECRET_KEY || 'your-secret-key-fallback'; // Use a strong, environment-specific key
+const SECRET_KEY = process.env.CRYPTO_SECRET_KEY;
+if (!SECRET_KEY) {
+  throw new Error('CRYPTO_SECRET_KEY environment variable is required');
+}
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))

--- a/src/scripts/import-tests.ts
+++ b/src/scripts/import-tests.ts
@@ -9,16 +9,29 @@ if (!file) {
 }
 
 const content = fs.readFileSync(file);
-const records = parse(content, { columns: true });
+interface CsvRecord {
+  name: string;
+  domain: string;
+  numQuestions: string;
+  instructions?: string;
+  scoringAlgorithm?: string;
+}
+
+const records = parse(content, { columns: true, skip_empty_lines: true }) as CsvRecord[];
 
 async function run() {
   for (const r of records) {
+    if (!r.name || !r.domain || isNaN(Number(r.numQuestions))) {
+      console.warn('Skipping invalid row', r);
+      continue;
+    }
+
     await adminDb.collection('testsLibrary').add({
-      name: r.name,
-      domain: r.domain,
+      name: r.name.trim(),
+      domain: r.domain.trim(),
       numQuestions: Number(r.numQuestions),
-      instructions: r.instructions,
-      scoringAlgorithm: r.scoringAlgorithm,
+      instructions: r.instructions?.trim() || '',
+      scoringAlgorithm: r.scoringAlgorithm?.trim() || '',
     });
   }
 }


### PR DESCRIPTION
## Summary
- enforce required secrets in `firebaseAdmin.ts` and `sendAssessmentLink`
- require `CRYPTO_SECRET_KEY` and stop exposing it client-side
- enable TypeScript and ESLint checks during build
- link Firestore rules in `firebase.json`
- validate CSV records in import script
- document new env var

## Testing
- `npm install`
- `CRYPTO_SECRET_KEY=test npm test`

------
https://chatgpt.com/codex/tasks/task_e_68423c64254c8324a1534a8808c89d3f