### PR TITLE
Address security concerns

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,3 @@
+# Exemplo de configuração local
+# Gere a chave com: openssl rand -base64 32
+CRYPTO_SECRET_KEY=PASTE_BASE64_KEY_HERE

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ next-env.d.ts
 # firebase
 firebase-debug.log
 firestore-debug.log
+
+!.env.local.example

--- a/docs/assessments-module.md
+++ b/docs/assessments-module.md
@@ -9,7 +9,7 @@
 
 ## Deploy
 
-1. Configure variáveis em `.env.local` e `.env` para chaves do Firebase, SendGrid e Twilio (`SENDGRID_API_KEY`, `SENDGRID_FROM_EMAIL`, `TWILIO_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_WHATSAPP_FROM`, `ASSESSMENT_TOKEN_SECRET`).
+1. Configure variáveis em `.env.local` e `.env` para chaves do Firebase, SendGrid e Twilio (`SENDGRID_API_KEY`, `SENDGRID_FROM_EMAIL`, `TWILIO_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_WHATSAPP_FROM`, `ASSESSMENT_TOKEN_SECRET`, `CRYPTO_SECRET_KEY (base64)`).
 2. Execute `npm install` para instalar dependências.
 3. Inicie os emuladores com `firebase emulators:start` para testes locais.
 4. Para deploy, rode `firebase deploy --only functions,firestore`.

--- a/docs/env.md
+++ b/docs/env.md
@@ -1,0 +1,50 @@
+# Variáveis de Ambiente
+
+Esta aplicação utiliza criptografia AES para campos sensíveis. Para funcionar em qualquer ambiente é necessário definir `CRYPTO_SECRET_KEY` com uma chave em base64 **sem o prefixo `NEXT_PUBLIC_`**.
+
+## Gerar chave
+
+Execute:
+
+```bash
+openssl rand -base64 32
+```
+
+## Desenvolvimento
+
+Crie um arquivo `.env.local` na raiz do projeto e adicione:
+
+```dotenv
+CRYPTO_SECRET_KEY=SEU_VALOR_BASE64
+```
+
+Se a variável não estiver presente em desenvolvimento, `getCryptoKey()` gera uma chave aleatória e mostra um aviso. Os dados criptografados nesse modo não poderão ser lidos após reiniciar o servidor.
+
+## CI/CD (GitHub Actions)
+
+Adicione `CRYPTO_SECRET_KEY` aos *Secrets* do repositório e exporte como variável de ambiente nos workflows.
+
+## Firebase Functions
+
+Defina a chave nos parâmetros do projeto e garanta que ela seja exposta como variável durante o deploy:
+
+```bash
+firebase functions:config:set secrets.crypto_key="<base64>"
+```
+
+## Snippet de regras (opcional)
+
+```firestore
+match /secrets/{document=**} {
+  allow read, write: if false;
+}
+```
+
+## Checklist de deploy
+
+1. `npm install`
+2. Criar/atualizar `.env.local`
+3. `firebase emulators:start` (testes locais)
+4. `npm run build`
+5. `firebase deploy --only functions,firestore`
+6. Verificar logs e regras publicadas

--- a/firebase.json
+++ b/firebase.json
@@ -2,6 +2,9 @@
   "functions": {
     "source": "functions"
   },
+  "firestore": {
+    "rules": "docs/firestore.rules"
+  },
   "emulators": {
     "apphosting": {
       "port": 5002,

--- a/functions/sendAssessmentLink.ts
+++ b/functions/sendAssessmentLink.ts
@@ -9,7 +9,10 @@ const db = admin.firestore();
 
 sgMail.setApiKey(process.env.SENDGRID_API_KEY as string);
 const twilioClient = twilio(process.env.TWILIO_SID as string, process.env.TWILIO_AUTH_TOKEN as string);
-const TOKEN_SECRET = process.env.ASSESSMENT_TOKEN_SECRET as string;
+const TOKEN_SECRET = process.env.ASSESSMENT_TOKEN_SECRET;
+if (!TOKEN_SECRET) {
+  throw new Error('ASSESSMENT_TOKEN_SECRET environment variable is required');
+}
 
 function signToken(data: { patientId: string; assessmentId: string }) {
   return jwt.sign(data, TOKEN_SECRET, { expiresIn: '7d' });

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,10 +3,10 @@ import type {NextConfig} from 'next';
 const nextConfig: NextConfig = {
   /* config options here */
   typescript: {
-    ignoreBuildErrors: true,
+    ignoreBuildErrors: false,
   },
   eslint: {
-    ignoreDuringBuilds: true,
+    ignoreDuringBuilds: false,
   },
   images: {
     remotePatterns: [

--- a/src/lib/firebaseAdmin.ts
+++ b/src/lib/firebaseAdmin.ts
@@ -14,7 +14,10 @@ if (!getApps().length) {
 export const adminDb = getFirestore(app);
 export const adminAuth = getAuth(app);
 
-const TOKEN_SECRET = process.env.ASSESSMENT_TOKEN_SECRET || 'secret';
+const TOKEN_SECRET = process.env.ASSESSMENT_TOKEN_SECRET;
+if (!TOKEN_SECRET) {
+  throw new Error('ASSESSMENT_TOKEN_SECRET environment variable is required');
+}
 
 export function signAssessmentToken(payload: { assessmentId: string; patientId: string }): string {
   return jwt.sign(payload, TOKEN_SECRET, { expiresIn: '7d' });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,27 +1,54 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
-import CryptoJS from 'crypto-js'; // Assuming you have crypto-js installed
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+import { randomBytes, createCipheriv, createDecipheriv } from 'crypto';
 
-const SECRET_KEY = process.env.NEXT_PUBLIC_CRYPTO_SECRET_KEY || 'your-secret-key-fallback'; // Use a strong, environment-specific key
+let cachedKey: Buffer | null = null;
+
+/**
+ * Returns the crypto key used for encryption.
+ * - Reads CRYPTO_SECRET_KEY as base64.
+ * - In development, generates a random key if not provided and logs a warning.
+ */
+export function getCryptoKey(): Buffer {
+  if (cachedKey) return cachedKey;
+  const envKey = process.env.CRYPTO_SECRET_KEY;
+  if (envKey) {
+    cachedKey = Buffer.from(envKey, 'base64');
+    return cachedKey;
+  }
+  if (process.env.NODE_ENV === 'development') {
+    console.warn(
+      'CRYPTO_SECRET_KEY not set. Using random key; encrypted data will be unreadable after restart.'
+    );
+    cachedKey = randomBytes(32);
+    return cachedKey;
+  }
+  throw new Error('CRYPTO_SECRET_KEY environment variable is required');
+}
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }
 
-/**
- * Encrypts a string using AES.
- * @param text The string to encrypt.
- * @returns The encrypted string.
- */
+const ALGORITHM = 'aes-256-cbc';
+const IV_LENGTH = 16;
+
+/** Encrypts a string using AES-256-CBC. Returns base64 `iv:ciphertext`. */
 export function encrypt(text: string): string {
-  return CryptoJS.AES.encrypt(text, SECRET_KEY).toString();
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, getCryptoKey(), iv);
+  const encrypted = Buffer.concat([cipher.update(text, 'utf8'), cipher.final()]);
+  return iv.toString('base64') + ':' + encrypted.toString('base64');
 }
 
-/**
- * Decrypts a string using AES.
- * @param ciphertext The string to decrypt.
- * @returns The decrypted string.
- */
-export function decrypt(ciphertext: string): string {
-  return CryptoJS.AES.decrypt(ciphertext, SECRET_KEY).toString(CryptoJS.enc.Utf8);
+/** Decrypts a string produced by `encrypt`. */
+export function decrypt(payload: string): string {
+  const [ivStr, data] = payload.split(':');
+  const iv = Buffer.from(ivStr, 'base64');
+  const decipher = createDecipheriv(ALGORITHM, getCryptoKey(), iv);
+  const decrypted = Buffer.concat([
+    decipher.update(Buffer.from(data, 'base64')),
+    decipher.final(),
+  ]);
+  return decrypted.toString('utf8');
 }

--- a/src/scripts/import-tests.ts
+++ b/src/scripts/import-tests.ts
@@ -9,16 +9,29 @@ if (!file) {
 }
 
 const content = fs.readFileSync(file);
-const records = parse(content, { columns: true });
+interface CsvRecord {
+  name: string;
+  domain: string;
+  numQuestions: string;
+  instructions?: string;
+  scoringAlgorithm?: string;
+}
+
+const records = parse(content, { columns: true, skip_empty_lines: true }) as CsvRecord[];
 
 async function run() {
   for (const r of records) {
+    if (!r.name || !r.domain || isNaN(Number(r.numQuestions))) {
+      console.warn('Skipping invalid row', r);
+      continue;
+    }
+
     await adminDb.collection('testsLibrary').add({
-      name: r.name,
-      domain: r.domain,
+      name: r.name.trim(),
+      domain: r.domain.trim(),
       numQuestions: Number(r.numQuestions),
-      instructions: r.instructions,
-      scoringAlgorithm: r.scoringAlgorithm,
+      instructions: r.instructions?.trim() || '',
+      scoringAlgorithm: r.scoringAlgorithm?.trim() || '',
     });
   }
 }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,3 +1,5 @@
+process.env.CRYPTO_SECRET_KEY = 'MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=';
+
 import { encrypt, decrypt } from '../src/lib/utils';
 
 describe('encrypt/decrypt', () => {


### PR DESCRIPTION
## Summary
- enforce required secrets in `firebaseAdmin.ts` and `sendAssessmentLink`
- require `CRYPTO_SECRET_KEY` and stop exposing it client-side
- enable TypeScript and ESLint checks during build
- link Firestore rules in `firebase.json`
- validate CSV records in import script
- document new env var
- refactor crypto util for safer runtime loading

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68423c64254c8324a1534a8808c89d3f