### PR TITLE
Improve crypto key handling

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,3 @@
+CRYPTO_SECRET_KEY=PASTE_BASE64_KEY_HERE
+
+# Outras variaveis

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ next-env.d.ts
 
 .genkit/*
 .env*
+!.env.local.example
 
 # firebase
 firebase-debug.log

--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 This is a Next.js starter in Firebase Studio.
 
-To get started, take a look at src/app/page.tsx.
+To get started, take a look at `src/app/page.tsx`.
+
+See [docs/env.md](docs/env.md) for environment variable configuration, including `CRYPTO_SECRET_KEY`.

--- a/docs/assessments-module.md
+++ b/docs/assessments-module.md
@@ -9,7 +9,7 @@
 
 ## Deploy
 
-1. Configure variáveis em `.env.local` e `.env` para chaves do Firebase, SendGrid e Twilio (`SENDGRID_API_KEY`, `SENDGRID_FROM_EMAIL`, `TWILIO_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_WHATSAPP_FROM`, `ASSESSMENT_TOKEN_SECRET`, `CRYPTO_SECRET_KEY`).
+1. Configure variáveis em `.env.local` e `.env` para chaves do Firebase, SendGrid e Twilio (`SENDGRID_API_KEY`, `SENDGRID_FROM_EMAIL`, `TWILIO_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_WHATSAPP_FROM`, `ASSESSMENT_TOKEN_SECRET`, `CRYPTO_SECRET_KEY`). Veja `docs/env.md` para detalhes sobre `CRYPTO_SECRET_KEY`.
 2. Execute `npm install` para instalar dependências.
 3. Inicie os emuladores com `firebase emulators:start` para testes locais.
 4. Para deploy, rode `firebase deploy --only functions,firestore`.

--- a/docs/env.md
+++ b/docs/env.md
@@ -1,0 +1,45 @@
+# Variáveis de Ambiente
+
+## CRYPTO_SECRET_KEY
+
+Chave usada para encriptar dados sensíveis. Deve ser uma string em base64 de 32 bytes.
+
+### Gerar chave
+
+```bash
+openssl rand -base64 32
+```
+
+### Onde definir
+
+- **Desenvolvimento**: crie um arquivo `.env.local` e coloque a chave.
+- **CI/CD (GitHub Actions)**: adicione como secret no repositório e carregue no workflow.
+- **Firebase Functions**:
+  ```bash
+  firebase functions:config:set secrets.crypto_key="<CHAVE_BASE64>"
+  ```
+  Após rodar `firebase deploy`, a chave fica acessível via `process.env.CRYPTO_SECRET_KEY`.
+
+### Importante
+
+Não use o prefixo `NEXT_PUBLIC_`; a chave não deve ir para o código do cliente.
+
+### Exemplo de `.env.local`
+
+```env
+CRYPTO_SECRET_KEY=PASTE_BASE64_KEY_HERE
+```
+
+### Regras Firebase (bloqueio opcional)
+
+```javascript
+match /secrets/{document=**} {
+  allow read, write: if false;
+}
+```
+
+### Checklist de Deploy
+
+1. Teste com `firebase emulators:start`.
+2. Execute `firebase deploy`.
+3. Verifique nos logs se a função leu `process.env.CRYPTO_SECRET_KEY` corretamente.

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,9 +1,24 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
-import CryptoJS from 'crypto-js';
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+import { randomBytes, createCipheriv, createDecipheriv } from 'crypto';
 
-const SECRET_KEY = process.env.CRYPTO_SECRET_KEY;
-if (!SECRET_KEY) {
+let cachedKey: Buffer | null = null;
+
+export function getCryptoKey(): Buffer {
+  if (cachedKey) return cachedKey;
+
+  const envKey = process.env.CRYPTO_SECRET_KEY;
+  if (envKey) {
+    cachedKey = Buffer.from(envKey, 'base64');
+    return cachedKey;
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    cachedKey = randomBytes(32);
+    console.warn('CRYPTO_SECRET_KEY not set. Using random key for development');
+    return cachedKey;
+  }
+
   throw new Error('CRYPTO_SECRET_KEY environment variable is required');
 }
 
@@ -17,7 +32,12 @@ export function cn(...inputs: ClassValue[]) {
  * @returns The encrypted string.
  */
 export function encrypt(text: string): string {
-  return CryptoJS.AES.encrypt(text, SECRET_KEY).toString();
+  const key = getCryptoKey();
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const encrypted = Buffer.concat([cipher.update(text, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, tag, encrypted]).toString('base64');
 }
 
 /**
@@ -26,5 +46,12 @@ export function encrypt(text: string): string {
  * @returns The decrypted string.
  */
 export function decrypt(ciphertext: string): string {
-  return CryptoJS.AES.decrypt(ciphertext, SECRET_KEY).toString(CryptoJS.enc.Utf8);
+  const data = Buffer.from(ciphertext, 'base64');
+  const iv = data.subarray(0, 12);
+  const tag = data.subarray(12, 28);
+  const text = data.subarray(28);
+  const decipher = createDecipheriv('aes-256-gcm', getCryptoKey(), iv);
+  decipher.setAuthTag(tag);
+  const decrypted = Buffer.concat([decipher.update(text), decipher.final()]);
+  return decrypted.toString('utf8');
 }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,3 +1,5 @@
+process.env.CRYPTO_SECRET_KEY = Buffer.from('01234567890123456789012345678901').toString('base64');
+
 import { encrypt, decrypt } from '../src/lib/utils';
 
 describe('encrypt/decrypt', () => {


### PR DESCRIPTION
## Summary
- allow `.env.local.example` so devs know how to configure secrets
- document how to configure env vars especially `CRYPTO_SECRET_KEY`
- reference docs in README and assessments docs
- new `getCryptoKey()` with runtime check and dev fallback
- use AES-256-GCM via Node `crypto`
- adjust tests for new API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684240f0ef608324a9d35b20c289cd03