### PR TITLE
Implement session note version history

### DIFF
--- a/functions/onSessionNoteUpdate.ts
+++ b/functions/onSessionNoteUpdate.ts
@@ -1,0 +1,31 @@
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin';
+
+admin.initializeApp();
+const db = admin.firestore();
+
+export const onSessionNoteUpdate = functions.firestore
+  .document('patients/{patientId}/sessionNotes/{noteId}')
+  .onUpdate(async (change, context) => {
+    const before = change.before.data() as any;
+    const after = change.after.data() as any;
+
+    // Only create a version if notes were modified
+    if (before.notes === after.notes && before.date === after.date) {
+      return null;
+    }
+
+    const versionsCol = db
+      .collection('patients')
+      .doc(context.params.patientId)
+      .collection('sessionNotes')
+      .doc(context.params.noteId)
+      .collection('versions');
+
+    await versionsCol.add({
+      ...before,
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+
+    return null;
+  });


### PR DESCRIPTION
## Summary
- add Cloud Function to store versions for session notes

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: many missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6842451cd930832487a85f8e09b3a20d