### PR TITLE
Add audit log viewing

### DIFF
--- a/src/app/(app)/tools/audit-log/page.tsx
+++ b/src/app/(app)/tools/audit-log/page.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useAuditLogs } from '@/hooks/useAuditLogs';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+export default function AuditLogPage() {
+  const { logs } = useAuditLogs();
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold font-headline">Audit Trail</h1>
+      <Card className="shadow-lg rounded-lg">
+        <CardHeader>
+          <CardTitle>Logs Registrados</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Ação</TableHead>
+                <TableHead>Usuário</TableHead>
+                <TableHead>Quando</TableHead>
+                <TableHead>Detalhes</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {logs.map(log => (
+                <TableRow key={log.id}>
+                  <TableCell>{log.action}</TableCell>
+                  <TableCell>{log.userId || '-'}</TableCell>
+                  <TableCell>{
+                    typeof log.timestamp === 'string'
+                      ? new Date(log.timestamp).toLocaleString()
+                      : (log.timestamp as any)?.toDate?.().toLocaleString()
+                  }</TableCell>
+                  <TableCell className="max-w-xs truncate">
+                    {log.details || '-'}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/hooks/useAudit.ts
+++ b/src/hooks/useAudit.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
+import { db } from '@/lib/firebaseClient';
+
+export function useAudit() {
+  return async function log(action: string, details: Record<string, any> = {}) {
+    await addDoc(collection(db, 'logs'), {
+      action,
+      timestamp: serverTimestamp(),
+      ...details,
+    });
+  };
+}

--- a/src/hooks/useAuditLogs.ts
+++ b/src/hooks/useAuditLogs.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { collection, onSnapshot, orderBy, query } from 'firebase/firestore';
+import { db } from '@/lib/firebaseClient';
+import type { AuditLogEntry } from '@/lib/types';
+
+export function useAuditLogs() {
+  const [logs, setLogs] = useState<AuditLogEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const q = query(collection(db, 'logs'), orderBy('timestamp', 'desc'));
+    const unsub = onSnapshot(q, snap => {
+      const data = snap.docs.map(d => ({ id: d.id, ...(d.data() as any) })) as AuditLogEntry[];
+      setLogs(data);
+      setLoading(false);
+    });
+
+    return () => unsub();
+  }, []);
+
+  return { logs, loading };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -137,3 +137,12 @@ export interface Task {
   updatedAt: string; // ISO 8601
   createdBy: string;
 }
+
+// 📝 Registro de auditoria
+export interface AuditLogEntry {
+  id: string;
+  action: string;
+  userId?: string;
+  timestamp: string; // ISO 8601 or Firestore timestamp string
+  details?: string;
+}


### PR DESCRIPTION
## Summary
- add `useAudit` and `useAuditLogs` hooks
- define `AuditLogEntry` type
- create audit trail page under `/tools/audit-log`

## Testing
- `npm install`
- `CRYPTO_SECRET_KEY=secret npm test`
- `npm run typecheck` *(fails: `functions/sendAssessmentLink.ts` etc.)*
- `npm run lint` *(fails: prompts for interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68424581cfd8832495e06f5e673787c7