### PR TITLE
Add timeline viewer page

### DIFF
--- a/src/app/(app)/analytics/timeline/page.tsx
+++ b/src/app/(app)/analytics/timeline/page.tsx
@@ -1,0 +1,36 @@
+import dynamic from 'next/dynamic';
+import { mockAppointments, mockPatients } from '@/lib/mock-data';
+import type { TimelineEvent } from '@/lib/types';
+
+const TimelineViewer = dynamic(() => import('@/components/analytics/TimelineViewer'), { ssr: false });
+
+export default function TimelinePage() {
+  const events: TimelineEvent[] = [];
+
+  mockAppointments.forEach((a) => {
+    events.push({
+      id: `appt-${a.id}`,
+      date: a.dateTime,
+      title: `Agendamento com ${a.patientName}`,
+      description: a.notes,
+    });
+  });
+
+  mockPatients.forEach((p) => {
+    p.sessionNotes.forEach((n) => {
+      events.push({
+        id: `note-${n.id}`,
+        date: n.date,
+        title: `Nota de sessão - ${p.name}`,
+        description: n.notes,
+      });
+    });
+  });
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold font-headline">Linha do Tempo</h1>
+      <TimelineViewer events={events} />
+    </div>
+  );
+}

--- a/src/components/analytics/TimelineViewer.tsx
+++ b/src/components/analytics/TimelineViewer.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import type { TimelineEvent } from '@/lib/types';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+
+interface TimelineViewerProps {
+  events: TimelineEvent[];
+}
+
+export default function TimelineViewer({ events }: TimelineViewerProps) {
+  const sorted = [...events].sort(
+    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+  );
+  return (
+    <div className="space-y-4">
+      {sorted.map((event) => (
+        <Card key={event.id}>
+          <CardHeader>
+            <CardTitle className="text-sm">
+              {new Date(event.date).toLocaleString()}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="font-medium">{event.title}</p>
+            {event.description && (
+              <p className="text-muted-foreground text-sm mt-1">
+                {event.description}
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -146,3 +146,11 @@ export interface AuditLogEntry {
   timestamp: string; // ISO 8601 or Firestore timestamp string
   details?: string;
 }
+
+// 📊 Evento para a Linha do Tempo
+export interface TimelineEvent {
+  id: string;
+  date: string; // ISO 8601
+  title: string;
+  description?: string;
+}


### PR DESCRIPTION
## Summary
- add TimelineViewer component
- add timeline page under analytics
- define TimelineEvent type

## Testing
- `CRYPTO_SECRET_KEY=test npm test`
- `npm run lint` *(fails: prompts for config)*
- `npm run typecheck` *(fails: TS errors about env var)*

------
https://chatgpt.com/codex/tasks/task_e_6842486acac4832485322c1e1606a65b