### PR TITLE
Add interactive timeline tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## [Unreleased]
+- Added: Módulo Linha do tempo interativa (no-breaking change)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -1,0 +1,19 @@
+# Módulo de Linha do Tempo Interativa
+
+Este módulo gera, apenas no client, uma lista unificada de eventos de pacientes e sessões.
+Não cria novas coleções ou campos no Firestore.
+
+## Uso
+
+- Rota: `/tools/timeline`
+- Hook: `useTimeline(patientId?)`
+- Context opcional: `TimelineProvider`
+
+## Testes manuais
+
+1. `npm run dev` e acesse `/tools/timeline`.
+2. Altere o paciente no seletor e verifique que apenas os eventos relacionados aparecem.
+
+## Deploy
+
+Nenhum comando adicional é necessário.

--- a/src/app/(app)/analytics/timeline/page.tsx
+++ b/src/app/(app)/analytics/timeline/page.tsx
@@ -1,3 +1,4 @@
+"use client";
 import dynamic from 'next/dynamic';
 import { mockAppointments, mockPatients } from '@/lib/mock-data';
 import type { TimelineEvent } from '@/lib/types';

--- a/src/app/(app)/tools/timeline/page.tsx
+++ b/src/app/(app)/tools/timeline/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import dynamic from 'next/dynamic';
+import { useState } from 'react';
+import { useTimeline } from '@/hooks/useTimeline';
+import { mockPatients } from '@/lib/mock-data';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select';
+
+const TimelineViewer = dynamic(() => import('@/components/analytics/TimelineViewer'), { ssr: false });
+
+export default function TimelineToolPage() {
+  const [patient, setPatient] = useState<string>('');
+  const { events } = useTimeline(patient || undefined);
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold font-headline">Linha do Tempo Interativa</h1>
+      <div className="w-64">
+        <Select value={patient} onValueChange={(v) => setPatient(v)}>
+          <SelectTrigger>
+            <SelectValue placeholder="Todos os pacientes" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="">Todos os pacientes</SelectItem>
+            {mockPatients.map((p) => (
+              <SelectItem key={p.id} value={p.id}>
+                {p.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <TimelineViewer events={events} />
+    </div>
+  );
+}

--- a/src/contexts/TimelineContext.tsx
+++ b/src/contexts/TimelineContext.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { createContext, useContext, useState } from 'react';
+import type { TimelineEvent } from '@/lib/types';
+
+interface TimelineContextValue {
+  events: TimelineEvent[];
+  setEvents: (events: TimelineEvent[]) => void;
+}
+
+const TimelineContext = createContext<TimelineContextValue | undefined>(undefined);
+
+export function TimelineProvider({ children }: { children: React.ReactNode }) {
+  const [events, setEvents] = useState<TimelineEvent[]>([]);
+
+  return (
+    <TimelineContext.Provider value={{ events, setEvents }}>
+      {children}
+    </TimelineContext.Provider>
+  );
+}
+
+export function useTimelineContext() {
+  const ctx = useContext(TimelineContext);
+  if (!ctx) {
+    throw new Error('useTimelineContext must be used within TimelineProvider');
+  }
+  return ctx;
+}

--- a/src/hooks/useTimeline.ts
+++ b/src/hooks/useTimeline.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import type { TimelineEvent } from '@/lib/types';
+import { generateTimelineEvents } from '@/lib/timeline';
+
+export function useTimeline(patientId?: string) {
+  const [events, setEvents] = useState<TimelineEvent[]>([]);
+
+  useEffect(() => {
+    setEvents(generateTimelineEvents(patientId));
+  }, [patientId]);
+
+  return { events };
+}

--- a/src/lib/timeline.ts
+++ b/src/lib/timeline.ts
@@ -1,0 +1,36 @@
+import type { TimelineEvent } from './types';
+import { mockAppointments, mockPatients } from './mock-data';
+
+export function generateTimelineEvents(patientId?: string): TimelineEvent[] {
+  const allEvents: TimelineEvent[] = [];
+
+  const appointments = patientId
+    ? mockAppointments.filter(a => a.patientId === patientId)
+    : mockAppointments;
+
+  appointments.forEach(a => {
+    allEvents.push({
+      id: `appt-${a.id}`,
+      date: a.dateTime,
+      title: `Agendamento com ${a.patientName}`,
+      description: a.notes,
+    });
+  });
+
+  const patients = patientId
+    ? mockPatients.filter(p => p.id === patientId)
+    : mockPatients;
+
+  patients.forEach(p => {
+    p.sessionNotes.forEach(n => {
+      allEvents.push({
+        id: `note-${n.id}`,
+        date: n.date,
+        title: `Nota de sessão - ${p.name}`,
+        description: n.notes,
+      });
+    });
+  });
+
+  return allEvents.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+}

--- a/tests/timeline.test.ts
+++ b/tests/timeline.test.ts
@@ -1,0 +1,12 @@
+import { generateTimelineEvents } from '../src/lib/timeline';
+import { mockAppointments, mockPatients } from '../src/lib/mock-data';
+
+test('generateTimelineEvents merges and sorts events', () => {
+  const events = generateTimelineEvents();
+  expect(events.length).toBe(mockAppointments.length + mockPatients.reduce((sum, p) => sum + p.sessionNotes.length, 0));
+  for (let i = 1; i < events.length; i++) {
+    const prev = new Date(events[i - 1].date).getTime();
+    const curr = new Date(events[i].date).getTime();
+    expect(prev).toBeLessThanOrEqual(curr);
+  }
+});


### PR DESCRIPTION
## Summary
- implement `useTimeline` hook and helper to merge events
- expose `TimelineProvider` context
- add `/tools/timeline` page with patient filter
- document timeline module
- add basic tests
- mark changelog

## Verification
- `grep -R --line-number 'sentimentScores\|sessionTags\|vectorRefs' src functions || echo "✅ livre"`
- `npm test`
- `npm run build` *(fails: PatientDetailPageProps constraint error)*

------
https://chatgpt.com/codex/tasks/task_e_68424d7c3994832496037ba94dce4e37