### PR TITLE
Add symptom heatmap page

### DIFF
--- a/src/app/(app)/analytics/symptom-heatmap/page.tsx
+++ b/src/app/(app)/analytics/symptom-heatmap/page.tsx
@@ -1,0 +1,15 @@
+import dynamic from 'next/dynamic';
+import { mockSymptomEntries } from '@/lib/mock-data';
+import type { SymptomHeatmapEntry } from '@/lib/types';
+
+const SymptomHeatmap = dynamic(() => import('@/components/analytics/SymptomHeatmap'), { ssr: false });
+
+export default function SymptomHeatmapPage() {
+  const entries: SymptomHeatmapEntry[] = mockSymptomEntries;
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold font-headline">Heatmap de Sintomas</h1>
+      <SymptomHeatmap entries={entries} />
+    </div>
+  );
+}

--- a/src/app/(app)/analytics/timeline/page.tsx
+++ b/src/app/(app)/analytics/timeline/page.tsx
@@ -1,0 +1,36 @@
+import dynamic from 'next/dynamic';
+import { mockAppointments, mockPatients } from '@/lib/mock-data';
+import type { TimelineEvent } from '@/lib/types';
+
+const TimelineViewer = dynamic(() => import('@/components/analytics/TimelineViewer'), { ssr: false });
+
+export default function TimelinePage() {
+  const events: TimelineEvent[] = [];
+
+  mockAppointments.forEach((a) => {
+    events.push({
+      id: `appt-${a.id}`,
+      date: a.dateTime,
+      title: `Agendamento com ${a.patientName}`,
+      description: a.notes,
+    });
+  });
+
+  mockPatients.forEach((p) => {
+    p.sessionNotes.forEach((n) => {
+      events.push({
+        id: `note-${n.id}`,
+        date: n.date,
+        title: `Nota de sessão - ${p.name}`,
+        description: n.notes,
+      });
+    });
+  });
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold font-headline">Linha do Tempo</h1>
+      <TimelineViewer events={events} />
+    </div>
+  );
+}

--- a/src/components/analytics/SymptomHeatmap.tsx
+++ b/src/components/analytics/SymptomHeatmap.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import type { SymptomHeatmapEntry } from "@/lib/types";
+import { eachDayOfInterval, startOfMonth, endOfMonth, format } from "date-fns";
+
+interface SymptomHeatmapProps {
+  entries: SymptomHeatmapEntry[];
+}
+
+export default function SymptomHeatmap({ entries }: SymptomHeatmapProps) {
+  const now = new Date();
+  const days = eachDayOfInterval({
+    start: startOfMonth(now),
+    end: endOfMonth(now),
+  });
+
+  const severityByDate: Record<string, number> = {};
+  entries.forEach((e) => {
+    severityByDate[e.date.slice(0, 10)] = e.severity;
+  });
+
+  const weeks: (Date | null)[][] = [];
+  let current: (Date | null)[] = Array(days[0].getDay()).fill(null);
+  days.forEach((d) => {
+    current.push(d);
+    if (current.length === 7) {
+      weeks.push(current);
+      current = [];
+    }
+  });
+  if (current.length) {
+    while (current.length < 7) current.push(null);
+    weeks.push(current);
+  }
+
+  const colors = [
+    "bg-gray-200",
+    "bg-green-200",
+    "bg-green-400",
+    "bg-yellow-300",
+    "bg-orange-400",
+    "bg-red-500",
+  ];
+
+  const labels = ["D", "S", "T", "Q", "Q", "S", "S"];
+
+  return (
+    <div className="space-y-1">
+      <div className="grid grid-cols-7 gap-1">
+        {labels.map((l) => (
+          <div key={l} className="text-center text-xs font-medium">
+            {l}
+          </div>
+        ))}
+      </div>
+      {weeks.map((week, i) => (
+        <div key={i} className="grid grid-cols-7 gap-1">
+          {week.map((day, j) => {
+            if (!day) return <div key={j} className="w-6 h-6" />;
+            const key = format(day, "yyyy-MM-dd");
+            const sev = severityByDate[key] || 0;
+            return (
+              <div
+                key={j}
+                className={`w-6 h-6 rounded ${colors[sev]}`}
+                title={`${key} - ${sev}`}
+              />
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/analytics/TimelineViewer.tsx
+++ b/src/components/analytics/TimelineViewer.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import type { TimelineEvent } from '@/lib/types';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+
+interface TimelineViewerProps {
+  events: TimelineEvent[];
+}
+
+export default function TimelineViewer({ events }: TimelineViewerProps) {
+  const sorted = [...events].sort(
+    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+  );
+  return (
+    <div className="space-y-4">
+      {sorted.map((event) => (
+        <Card key={event.id}>
+          <CardHeader>
+            <CardTitle className="text-sm">
+              {new Date(event.date).toLocaleString()}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="font-medium">{event.title}</p>
+            {event.description && (
+              <p className="text-muted-foreground text-sm mt-1">
+                {event.description}
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -1,3 +1,5 @@
+
+import { format, addDays } from "date-fns";
 import type {
   Patient,
   Appointment,
@@ -8,6 +10,7 @@ import type {
   KnowledgeBaseArticle,
   FinanceRecord,
   Medication,
+  SymptomHeatmapEntry,
 } from '@/lib/types';
 
 // 👤 Usuário mock
@@ -277,4 +280,12 @@ export const mockMedications: Medication[] = [
     indications: 'Transtorno de ansiedade, crises convulsivas',
     sideEffects: 'Sedação, tontura, dependência'
   }
+];
+
+export const mockSymptomEntries: SymptomHeatmapEntry[] = [
+  { id: 'sym-001', patientId: 'patient-001', date: format(addDays(new Date(), -5), 'yyyy-MM-dd'), symptom: 'Ansiedade', severity: 3 },
+  { id: 'sym-002', patientId: 'patient-001', date: format(addDays(new Date(), -4), 'yyyy-MM-dd'), symptom: 'Ansiedade', severity: 2 },
+  { id: 'sym-003', patientId: 'patient-001', date: format(addDays(new Date(), -3), 'yyyy-MM-dd'), symptom: 'Ansiedade', severity: 4 },
+  { id: 'sym-004', patientId: 'patient-001', date: format(addDays(new Date(), -2), 'yyyy-MM-dd'), symptom: 'Ansiedade', severity: 5 },
+  { id: 'sym-005', patientId: 'patient-001', date: format(addDays(new Date(), -1), 'yyyy-MM-dd'), symptom: 'Ansiedade', severity: 1 },
 ];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -146,3 +146,20 @@ export interface AuditLogEntry {
   timestamp: string; // ISO 8601 or Firestore timestamp string
   details?: string;
 }
+
+// 📊 Evento para a Linha do Tempo
+export interface TimelineEvent {
+  id: string;
+  date: string; // ISO 8601
+  title: string;
+  description?: string;
+}
+
+// 🔥 Entrada para o Heatmap de Sintomas
+export interface SymptomHeatmapEntry {
+  id: string;
+  patientId: string;
+  date: string; // ISO 8601
+  symptom: string;
+  severity: number; // 1-5
+}


### PR DESCRIPTION
## Summary
- create SymptomHeatmap component
- add mock symptom entries
- include SymptomHeatmapEntry type
- add /analytics/symptom-heatmap page

## Testing
- `CRYPTO_SECRET_KEY=test npm test`
- `npm run lint` *(fails: prompts for config)*
- `npm run typecheck` *(fails: TS errors about env vars)*

------
https://chatgpt.com/codex/tasks/task_e_6842486acac4832485322c1e1606a65b