### PR TITLE
Add richer mock dataset

### DIFF
--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -53,6 +53,22 @@ const initialSessionNotesP2: SessionNote[] = [
   },
 ];
 
+// 📝 Notas mock – paciente 3
+const initialSessionNotesP3: SessionNote[] = [
+  {
+    id: 'sn004',
+    date: new Date(new Date().setDate(today.getDate() - 21)).toISOString(),
+    notes: 'Primeira consulta. Queixas de dores de cabeça recorrentes sem causa física aparente.',
+    patientHistorySummaryForAI: 'Paciente referenciado por médico clínico geral.',
+  },
+  {
+    id: 'sn005',
+    date: new Date(new Date().setDate(today.getDate() - 5)).toISOString(),
+    notes: 'Relatou melhora significativa após iniciar prática de meditação diária.',
+    patientHistorySummaryForAI: 'Primeira consulta com queixas de dores de cabeça recorrentes.',
+  },
+];
+
 // 👩‍⚕️ Pacientes mock
 export let mockPatients: Patient[] = [
   {
@@ -75,6 +91,13 @@ export let mockPatients: Patient[] = [
     contact: 'charlie@example.com',
     dateOfBirth: '2000-02-10',
     sessionNotes: [],
+  },
+  {
+    id: 'patient-004',
+    name: 'Dana Scully',
+    contact: 'dana@example.com',
+    dateOfBirth: '1974-02-23',
+    sessionNotes: initialSessionNotesP3,
   },
 ];
 
@@ -161,6 +184,23 @@ export const mockAppointments: Appointment[] = [
     durationMinutes: 50,
     status: 'pending',
   },
+  {
+    id: 'appt-005',
+    patientId: 'patient-004',
+    patientName: 'Dana Scully',
+    dateTime: new Date(tomorrow.getFullYear(), tomorrow.getMonth(), tomorrow.getDate(), 16, 0).toISOString(),
+    durationMinutes: 50,
+    status: 'pending',
+  },
+  {
+    id: 'appt-006',
+    patientId: 'patient-002',
+    patientName: 'Bob The Builder',
+    dateTime: new Date(nextWeek.getFullYear(), nextWeek.getMonth(), nextWeek.getDate(), 13, 30).toISOString(),
+    durationMinutes: 50,
+    status: 'rescheduled',
+    notes: 'Reagendado pelo paciente.',
+  },
 ];
 
 // ⏳ Lista de espera mock
@@ -179,6 +219,14 @@ export const mockWaitingList: WaitingListItem[] = [
     contact: 'clark@example.com',
     addedDate: new Date(today.setDate(today.getDate() - 3)).toISOString(),
     notes: 'Encaminhamento urgente do Dr. Hamilton.',
+  },
+  {
+    id: 'wait-003',
+    patientName: 'Bruce Wayne',
+    contact: 'bruce@example.com',
+    requestedDate: 'Manhãs de segunda-feira',
+    addedDate: today.toISOString(),
+    notes: 'Prefere sessões presenciais.',
   },
 ];
 
@@ -208,6 +256,12 @@ export const mockFinanceRecords: FinanceRecord[] = [
     amount: 200,
     description: 'Sessão do mês anterior',
   },
+  {
+    id: 'fin-005',
+    date: new Date(today.getFullYear(), today.getMonth(), 18).toISOString(),
+    amount: 250,
+    description: 'Sessão em grupo',
+  },
 ];
 
 // 📑 Modelos de texto reutilizáveis
@@ -223,6 +277,12 @@ export const mockTemplates: Template[] = [
     name: 'Email de Lembrete',
     category: 'email',
     content: 'Olá {{nome}}, este é um lembrete do seu próximo agendamento...'
+  },
+  {
+    id: 'tpl-003',
+    name: 'Plano Terapêutico Básico',
+    category: 'treatment-plan',
+    content: 'Objetivos, metas e intervenções sugeridas para as próximas 8 semanas.'
   }
 ];
 
@@ -244,6 +304,11 @@ export const mockKnowledgeBaseArticles: KnowledgeBaseArticle[] = [
     question: 'Os dados são criptografados?',
     answer:
       'Este protótipo usa criptografia apenas em campos selecionados. Veja a documentação para mais detalhes.'
+  },
+  {
+    id: 'kb-004',
+    question: 'Como exportar os registros financeiros?',
+    answer: 'Na seção de Relatórios, escolha "Exportar Finanças" para gerar um arquivo CSV.'
   }
 ];
 
@@ -276,5 +341,12 @@ export const mockMedications: Medication[] = [
     class: 'Benzodiazepínico',
     indications: 'Transtorno de ansiedade, crises convulsivas',
     sideEffects: 'Sedação, tontura, dependência'
+  },
+  {
+    id: 'med-005',
+    name: 'Quetiapina',
+    class: 'Antipsicótico atípico',
+    indications: 'Transtorno bipolar, esquizofrenia',
+    sideEffects: 'Sonolência, ganho de peso'
   }
 ];


### PR DESCRIPTION
## Summary
- expand mock data to cover more patients and records
- additional appointments, waiting list entries, finance logs, templates, articles and medications

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842551a510883248324468c478d1106