### PR TITLE
Refactor layout and add dashboard utilities

### DIFF
--- a/src/components/dashboard/MetricCard.tsx
+++ b/src/components/dashboard/MetricCard.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { LucideIcon } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface MetricCardProps {
+  icon: LucideIcon;
+  title: string;
+  value: React.ReactNode;
+  description?: string;
+  children?: React.ReactNode;
+}
+
+export default function MetricCard({ icon: Icon, title, value, description, children }: MetricCardProps) {
+  return (
+    <Card className="shadow-md rounded-xl">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium">{title}</CardTitle>
+        <Icon className="h-5 w-5 opacity-10" />
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-bold">{value}</div>
+        {description && <p className="text-xs text-muted-foreground">{description}</p>}
+        {children}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/WelcomeCard.tsx
+++ b/src/components/dashboard/WelcomeCard.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import Image from 'next/image';
+import { useAuth } from '@/contexts/AuthContext';
+import { useBannerImage } from '@/hooks/useBannerImage';
+
+export default function WelcomeCard() {
+  const { user } = useAuth();
+  const banner = useBannerImage();
+
+  if (!user) return null;
+
+  return (
+    <div className="bg-primary/10 rounded-xl p-6 grid gap-4 lg:grid-cols-3 items-center">
+      <div className="lg:col-span-2">
+        <h2 className="text-3xl font-bold">Bem-vindo(a), {user.name}!</h2>
+        <p className="text-muted-foreground mt-1">Aqui está um resumo da sua atividade recente.</p>
+      </div>
+      {banner && (
+        <Image
+          src={banner}
+          alt="Banner"
+          width={300}
+          height={200}
+          className="rounded-lg mx-auto lg:mx-0"
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 import { Button } from '@/components/ui/button';
-import { Menu } from 'lucide-react';
-import { AppSidebar } from './Sidebar'; // Import the new sidebar
+import AppSidebar from './Sidebar';
 import { NotificationBell } from './NotificationBell';
+import { Logo } from '@/components/Logo';
 import { useAuth } from '@/contexts/AuthContext';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { ThemeToggle } from '@/components/ui/theme-toggle';
@@ -38,27 +37,18 @@ export function AppHeader() {
 
 
   return (
-    <header className="sticky top-0 z-30 flex h-16 items-center gap-4 border-b bg-background/80 backdrop-blur-sm px-4 md:px-6 justify-between md:justify-end">
-      <div className="md:hidden">
-         <Sheet>
-          <SheetTrigger asChild>
-            <Button variant="outline" size="icon">
-              <Menu className="h-5 w-5" />
-              <span className="sr-only">Toggle navigation menu</span>
-            </Button>
-          </SheetTrigger>
-          <SheetContent side="left" className="p-0 w-[280px] flex flex-col">
-            {/* Embed AppSidebar content here for mobile */}
-            <AppSidebar /> 
-          </SheetContent>
-        </Sheet>
+    <header className="sticky top-0 z-30 flex h-16 items-center justify-between gap-4 border-b bg-background/80 backdrop-blur-sm px-4 md:px-6">
+      <div className="flex items-center gap-4">
+        <AppSidebar />
+        <Logo />
       </div>
 
-      <NotificationBell />
-      <ThemeToggle />
+      <div className="flex items-center gap-4 ml-auto">
+        <NotificationBell />
+        <ThemeToggle />
 
-      {user && (
-         <DropdownMenu>
+        {user && (
+          <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="ghost" className="relative h-10 w-10 rounded-full">
                 <Avatar className="h-10 w-10">
@@ -92,7 +82,8 @@ export function AppHeader() {
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
-      )}
+        )}
+      </div>
     </header>
   );
 }

--- a/src/components/layout/NotificationBell.tsx
+++ b/src/components/layout/NotificationBell.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
 } from '@/components/ui/dropdown-menu';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useNotifications } from '@/contexts/NotificationContext';
 
 export function NotificationBell() {
@@ -18,15 +19,20 @@ export function NotificationBell() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" className="relative h-10 w-10" data-ai-hint="notification bell">
-          <Bell className="h-5 w-5" />
-          {unreadCount > 0 && (
-            <span className="absolute top-0 right-0 inline-flex items-center justify-center px-1.5 py-0.5 text-[10px] font-bold leading-none text-white transform translate-x-1/2 -translate-y-1/2 bg-red-600 rounded-full">
-              {unreadCount}
-            </span>
-          )}
-          <span className="sr-only">Abrir notificações</span>
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="ghost" className="relative h-10 w-10" data-ai-hint="notification bell">
+              <Bell className="h-5 w-5" />
+              {unreadCount > 0 && (
+                <span className="absolute top-0 right-0 inline-flex items-center justify-center px-1.5 py-0.5 text-[10px] font-bold leading-none bg-secondary text-secondary-foreground transform translate-x-1/2 -translate-y-1/2 rounded-full">
+                  {unreadCount}
+                </span>
+              )}
+              <span className="sr-only">Abrir notificações</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{unreadCount} notificações</TooltipContent>
+        </Tooltip>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-72">
         <DropdownMenuLabel className="flex justify-between items-center">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,150 +1,110 @@
 "use client";
 
+import { usePathname } from 'next/navigation';
 import Link from 'next/link';
-import { usePathname, useRouter } from 'next/navigation';
-import {
-  LayoutDashboard,
-  Users,
-  CalendarDays,
-  ListChecks,
-  FileText,
-  LogOut,
-  Settings,
-  PanelLeft,
-  BookOpenCheck,
-  HeartPulse,
-  LineChart,
-  Pill,
-} from 'lucide-react';
-import { Button } from '@/components/ui/button';
 import { useAuth } from '@/contexts/AuthContext';
 import { Logo } from '@/components/Logo';
+import { Button } from '@/components/ui/button';
+import { Sheet, SheetContent } from '@/components/ui/sheet';
+import { Menu, LayoutDashboard, Users, CalendarDays, ListChecks, FileText, Pill, HeartPulse, BookOpenCheck, LineChart, Settings, LogOut } from 'lucide-react';
+import { useState, useEffect } from 'react';
 import { cn } from '@/lib/utils';
-import {
-  SidebarProvider,
-  Sidebar,
-  SidebarHeader,
-  SidebarContent,
-  SidebarFooter,
-  SidebarMenu,
-  SidebarMenuItem,
-  SidebarMenuButton,
-  SidebarSeparator,
-  SidebarTrigger,
-  SidebarInset,
-} from "@/components/ui/sidebar";
 
-const navItems = [
-  { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
-  { href: '/patients', label: 'Pacientes', icon: Users },
-  { href: '/appointments', label: 'Agendamentos', icon: CalendarDays },
-  { href: '/waiting-list', label: 'Lista de Espera', icon: ListChecks },
-  { href: '/templates', label: 'Modelos', icon: FileText },
-  { href: '/medications', label: 'Medicamentos', icon: Pill },
-  { href: '/self-care', label: 'Saúde Mental', icon: HeartPulse },
-  { href: '/knowledge-base', label: 'Base de Conhecimento', icon: BookOpenCheck },
-  { href: '/analytics', label: 'Tendências', icon: LineChart },
-  { href: '/settings', label: 'Configurações', icon: Settings },
+const sections = [
+  {
+    title: 'Consultório',
+    items: [
+      { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
+      { href: '/patients', label: 'Pacientes', icon: Users },
+      { href: '/appointments', label: 'Agendamentos', icon: CalendarDays },
+      { href: '/waiting-list', label: 'Lista de Espera', icon: ListChecks },
+    ],
+  },
+  {
+    title: 'Ferramentas',
+    items: [
+      { href: '/templates', label: 'Modelos', icon: FileText },
+      { href: '/medications', label: 'Medicamentos', icon: Pill },
+      { href: '/self-care', label: 'Saúde Mental', icon: HeartPulse },
+      { href: '/knowledge-base', label: 'Base de Conhecimento', icon: BookOpenCheck },
+      { href: '/analytics', label: 'Tendências', icon: LineChart },
+    ],
+  },
+  {
+    title: 'Sistema',
+    items: [
+      { href: '/settings', label: 'Configurações', icon: Settings },
+    ],
+  },
 ];
 
-// Choose the most important features to appear in the top vertical section
-const leftItems = [
-  navItems[0], // Dashboard
-  navItems[1], // Pacientes
-  navItems[2], // Agendamentos
-];
-
-const rightItems = navItems.filter((item) => !leftItems.includes(item));
-
-export function LeftSidebar() {
+function SidebarContent({ className }: { className?: string }) {
   const pathname = usePathname();
   const { logout, user } = useAuth();
-  const router = useRouter();
-
-  const handleLogout = async () => {
-    await logout();
-    router.push('/login');
-  };
-
   return (
-    <Sidebar className="border-r bg-card" collapsible="icon" side="left">
-      <SidebarHeader className="p-4">
-        <Link href="/dashboard" className="mb-4 block">
+    <div className={cn('w-[240px] bg-card border-r flex flex-col', className)}>
+      <div className="p-4">
+        <Link href="/dashboard">
           <Logo />
         </Link>
-      </SidebarHeader>
-      <SidebarContent className="flex-grow p-2 space-y-2">
-        <SidebarMenu>
-          {leftItems.map((item) => (
-            <SidebarMenuItem key={item.href}>
-              <Link href={item.href}>
-                <SidebarMenuButton
-                  variant="default"
-                  className={cn(
-                    'w-full justify-start text-base h-12',
-                    pathname === item.href ||
-                      (pathname.startsWith(item.href) && item.href !== '/dashboard')
-                      ? 'bg-primary/10 text-primary font-semibold'
-                      : 'hover:bg-primary/5'
-                  )}
-                  tooltip={{ children: item.label, side: 'right', align: 'center', className: 'ml-2' }}
-                >
-                  <item.icon className="h-5 w-5 mr-3" />
-                  <span className="truncate">{item.label}</span>
-                </SidebarMenuButton>
-              </Link>
-            </SidebarMenuItem>
-          ))}
-        </SidebarMenu>
-      </SidebarContent>
-      <SidebarFooter className="p-4 border-t">
-        {user && (
-          <div className="mb-4 text-center group-data-[collapsible=icon]:hidden">
-            <p className="font-semibold text-sm">{user.name}</p>
-            <p className="text-xs text-muted-foreground">{user.email}</p>
+      </div>
+      <nav className="flex-1 overflow-y-auto px-2 space-y-6 text-sm">
+        {sections.map(section => (
+          <div key={section.title} className="space-y-1">
+            <p className="px-2 text-muted-foreground font-semibold mb-1">{section.title}</p>
+            <ul className="space-y-1">
+              {section.items.map(item => (
+                <li key={item.href}>
+                  <Link
+                    href={item.href}
+                    className={cn('flex items-center gap-2 rounded-md px-2 py-2 hover:bg-primary/20',
+                      pathname === item.href && 'bg-primary/20 font-semibold')}
+                  >
+                    <item.icon className="h-[18px] w-[18px]" />
+                    <span>{item.label}</span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
           </div>
+        ))}
+      </nav>
+      <div className="border-t p-4 max-[480px]:hidden">
+        {user && (
+          <p className="mb-2 text-sm font-medium">{user.name}</p>
         )}
-        <Button variant="ghost" onClick={handleLogout} className="w-full justify-start text-base h-12 group-data-[collapsible=icon]:px-2">
-          <LogOut className="h-5 w-5 mr-3 group-data-[collapsible=icon]:mr-0" />
-          <span className="truncate group-data-[collapsible=icon]:hidden">Sair</span>
+        <Button variant="ghost" className="w-full justify-start" onClick={logout}>
+          <LogOut className="h-[18px] w-[18px] mr-2" /> Sair
         </Button>
-      </SidebarFooter>
-    </Sidebar>
+      </div>
+    </div>
   );
 }
 
-export function RightSidebar() {
-  const pathname = usePathname();
+export default function AppSidebar() {
+  const [open, setOpen] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia('(min-width: 1024px)');
+    const handle = () => setIsDesktop(mq.matches);
+    handle();
+    mq.addEventListener('change', handle);
+    return () => mq.removeEventListener('change', handle);
+  }, []);
+
+  if (isDesktop) {
+    return <SidebarContent />;
+  }
 
   return (
-    <Sidebar className="border-l bg-card" collapsible="icon" side="right">
-      <SidebarContent className="flex-grow p-2 space-y-2">
-        <SidebarMenu>
-          {rightItems.map((item) => (
-            <SidebarMenuItem key={item.href}>
-              <Link href={item.href}>
-                <SidebarMenuButton
-                  variant="default"
-                  className={cn(
-                    'w-full justify-start text-base h-12',
-                    pathname === item.href ||
-                      (pathname.startsWith(item.href) && item.href !== '/dashboard')
-                      ? 'bg-primary/10 text-primary font-semibold'
-                      : 'hover:bg-primary/5'
-                  )}
-                  tooltip={{ children: item.label, side: 'left', align: 'center', className: 'mr-2' }}
-                >
-                  <item.icon className="h-5 w-5 mr-3" />
-                  <span className="truncate">{item.label}</span>
-                </SidebarMenuButton>
-              </Link>
-            </SidebarMenuItem>
-          ))}
-        </SidebarMenu>
-      </SidebarContent>
-    </Sidebar>
+    <Sheet open={open} onOpenChange={setOpen}>
+      <Button variant="ghost" size="icon" onClick={() => setOpen(true)}>
+        <Menu className="h-5 w-5" />
+      </Button>
+      <SheetContent side="left" className="p-0">
+        <SidebarContent className="h-full" />
+      </SheetContent>
+    </Sheet>
   );
 }
-
-export { LeftSidebar as AppSidebar };
-

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -13,7 +13,7 @@ interface ThemeContextType {
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export const ThemeProvider = ({ children }: { children: ReactNode }) => {
-  const [theme, setThemeState] = useState<Theme>('light');
+  const [theme, setThemeState] = useState<Theme>('dark');
 
   useEffect(() => {
     const stored = localStorage.getItem('psiguard_theme');

--- a/src/hooks/useBannerImage.ts
+++ b/src/hooks/useBannerImage.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+
+export function useBannerImage() {
+  const [url, setUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchImage() {
+      try {
+        const res = await fetch('https://source.unsplash.com/featured/600x200?clinic');
+        setUrl(res.url);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+    fetchImage();
+  }, []);
+
+  return url;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type {Config} from 'tailwindcss';
+import colors from 'tailwindcss/colors';
 
 export default {
   darkMode: ['class'],
@@ -38,9 +39,11 @@ export default {
           foreground: 'hsl(var(--muted-foreground))',
         },
         accent: {
+          ...colors.green,
           DEFAULT: 'hsl(var(--accent))',
           foreground: 'hsl(var(--accent-foreground))',
         },
+        warning: colors.amber,
         destructive: {
           DEFAULT: 'hsl(var(--destructive))',
           foreground: 'hsl(var(--destructive-foreground))',


### PR DESCRIPTION
## Summary
- refactor sidebar with sectioned navigation and drawer behavior
- adjust header actions and notification tooltip
- set dark theme as default
- add helper for fetching dashboard banner images
- introduce WelcomeCard and MetricCard components
- extend Tailwind palette with accent and warning colors

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run build` *(fails: build did not finish in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_684254c0d44883248f3364ee5ab503cf