### PR TITLE
Add useSmartMenu hook

### DIFF
--- a/src/lib/use-smart-menu/ScrollLock.ts
+++ b/src/lib/use-smart-menu/ScrollLock.ts
@@ -1,0 +1,15 @@
+let scrollTop = 0;
+
+export function lockScroll() {
+  scrollTop = window.scrollY || window.pageYOffset;
+  document.body.style.top = `-${scrollTop}px`;
+  document.body.style.position = 'fixed';
+  document.body.style.width = '100%';
+}
+
+export function unlockScroll() {
+  document.body.style.position = '';
+  document.body.style.top = '';
+  document.body.style.width = '';
+  window.scrollTo(0, scrollTop);
+}

--- a/src/lib/use-smart-menu/types.ts
+++ b/src/lib/use-smart-menu/types.ts
@@ -1,0 +1,12 @@
+export interface SmartMenuAnimation {
+  delay?: number;
+  duration?: number;
+  easing?: string;
+}
+
+export interface SmartMenuConfig {
+  id: string;
+  animation?: SmartMenuAnimation;
+  restoreFocus?: boolean;
+  persistFocus?: boolean;
+}

--- a/src/lib/use-smart-menu/useSmartMenu.ts
+++ b/src/lib/use-smart-menu/useSmartMenu.ts
@@ -1,0 +1,56 @@
+import { useEffect, useRef, useState } from 'react';
+import { lockScroll, unlockScroll } from './ScrollLock';
+import type { SmartMenuConfig } from './types';
+
+export function useSmartMenu(config: SmartMenuConfig) {
+  const { id, animation, restoreFocus = true, persistFocus = true } = config;
+  const [open, setOpen] = useState(() => localStorage.getItem(`menu:${id}`) === 'true');
+  const ref = useRef<HTMLElement>(null);
+
+  const toggle = () => {
+    setOpen(prev => {
+      const next = !prev;
+      localStorage.setItem(`menu:${id}`, next.toString());
+      return next;
+    });
+  };
+
+  const saveFocus = (href: string) => {
+    if (persistFocus) localStorage.setItem(`menu:${id}:focus`, href);
+  };
+
+  useEffect(() => {
+    if (open) {
+      lockScroll();
+      if (restoreFocus) {
+        const href = localStorage.getItem(`menu:${id}:focus`);
+        const el =
+          ref.current?.querySelector(`a[href='${href}']`) || ref.current?.querySelector('a');
+        setTimeout(() => (el as HTMLElement)?.focus(), animation?.delay ?? 150);
+      }
+    } else {
+      unlockScroll();
+    }
+    return unlockScroll;
+  }, [open]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && open) setOpen(false);
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open]);
+
+  return {
+    open,
+    toggle,
+    setOpen,
+    ref,
+    saveFocus,
+    animation: {
+      duration: animation?.duration ?? 250,
+      easing: animation?.easing ?? 'ease-in-out',
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add a useSmartMenu React hook for menus
- include ScrollLock helpers
- add related TypeScript types

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684327e058c48324b63a89110d15fe3b