### PR TITLE
Add smart menu index file

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -15,7 +15,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { useSmartMenu } from '@/lib/use-smart-menu/useSmartMenu';
+import { useSmartMenu } from '@/lib/use-smart-menu';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useRef, useEffect } from 'react';
 import { useRouter } from 'next/navigation';

--- a/src/lib/use-smart-menu/index.ts
+++ b/src/lib/use-smart-menu/index.ts
@@ -1,0 +1,3 @@
+export { useSmartMenu } from './useSmartMenu';
+export * from './ScrollLock';
+export * from './types';


### PR DESCRIPTION
## Summary
- export the `use-smart-menu` API via a new barrel file
- switch the header component to use the new import

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68433bd8d63c8324a5ac6218cf4cc951