### PR TITLE
Add useFloatingMenu hook

### DIFF
--- a/src/lib/use-smart-menu/index.ts
+++ b/src/lib/use-smart-menu/index.ts
@@ -1,3 +1,4 @@
 export { useSmartMenu } from './useSmartMenu';
+export { useFloatingMenu } from './useFloatingMenu';
 export * from './ScrollLock';
 export * from './types';

--- a/src/lib/use-smart-menu/useFloatingMenu.ts
+++ b/src/lib/use-smart-menu/useFloatingMenu.ts
@@ -1,0 +1,21 @@
+import { useFloating, offset, flip, shift } from '@floating-ui/react-dom';
+import { useSmartMenu } from './useSmartMenu';
+import type { SmartMenuConfig } from './types';
+
+export function useFloatingMenu(config: SmartMenuConfig) {
+  const menu = useSmartMenu(config);
+  const floating = useFloating({
+    middleware: [offset(8), flip(), shift({ padding: 8 })],
+    whileElementsMounted: (reference, floating, update) => {
+      const observer = new ResizeObserver(update);
+      observer.observe(reference);
+      observer.observe(floating);
+      return () => observer.disconnect();
+    },
+  });
+
+  return {
+    ...menu,
+    floating,
+  };
+}


### PR DESCRIPTION
## Summary
- add `useFloatingMenu` to integrate floating UI with `useSmartMenu`
- export the new hook from the smart menu library

## Testing
- `npm run typecheck` *(fails: src/app/(app)/layout.tsx(48,1): error TS1005: '}' expected.)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433d93e8ac8324aa2b318615cbfcf7