### PR TITLE
Refactor delete confirmations with SmartModal

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -45,3 +45,4 @@ export default function AppLayout({
       </SidebarProvider>
     </div>
   );
+}

--- a/src/components/SmartModal.tsx
+++ b/src/components/SmartModal.tsx
@@ -29,6 +29,9 @@ export function SmartModal({ id, open, onClose, title, children }: SmartModalPro
     <AnimatePresence>
       {isOpen && (
         <motion.div
+          onClick={(e) => {
+            if (e.target === e.currentTarget) modal.setOpen(false);
+          }}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}

--- a/src/components/appointments/AppointmentCalendarView.tsx
+++ b/src/components/appointments/AppointmentCalendarView.tsx
@@ -33,17 +33,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog";
+import { SmartModal } from "@/components/SmartModal";
 import { useToast } from "@/hooks/use-toast";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -70,6 +60,7 @@ export function AppointmentCalendarView({
   const [selectedDate, setSelectedDate] = useState<Date | undefined>(new Date());
   const [editingAppointment, setEditingAppointment] = useState<Appointment | null>(null);
   const [isFormOpen, setIsFormOpen] = useState(false);
+  const [toDelete, setToDelete] = useState<Appointment | null>(null);
   const { toast } = useToast();
 
   const handleEdit = (appointment: Appointment) => {
@@ -271,36 +262,36 @@ export function AppointmentCalendarView({
                             </TooltipContent>
                           </Tooltip>
 
-                          <AlertDialog>
-                            <AlertDialogTrigger asChild>
+                          <Button
+                            variant="destructive"
+                            size="icon"
+                            className="h-9 w-9"
+                            onClick={() => setToDelete(app)}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                          <SmartModal
+                            id="delete-appointment"
+                            open={toDelete?.id === app.id}
+                            onClose={() => setToDelete(null)}
+                            title="Confirmar Exclusão"
+                          >
+                            <p className="text-sm">
+                              Tem certeza que deseja excluir este agendamento para {app.patientName} em {format(appDateTime, "dd/MM/yyyy 'às' HH:mm")}? 
+                            </p>
+                            <div className="mt-4 flex justify-end gap-2">
+                              <Button onClick={() => setToDelete(null)}>Cancelar</Button>
                               <Button
                                 variant="destructive"
-                                size="icon"
-                                className="h-9 w-9"
+                                onClick={() => {
+                                  handleDelete(app.id);
+                                  setToDelete(null);
+                                }}
                               >
-                                <Trash2 className="h-4 w-4" />
+                                Excluir
                               </Button>
-                            </AlertDialogTrigger>
-                            <AlertDialogContent>
-                              <AlertDialogHeader>
-                                <AlertDialogTitle>Confirmar Exclusão</AlertDialogTitle>
-                                <AlertDialogDescription>
-                                  Tem certeza que deseja excluir este agendamento
-                                  para {app.patientName} em{" "}
-                                  {format(appDateTime, "dd/MM/yyyy 'às' HH:mm")}?
-                                </AlertDialogDescription>
-                              </AlertDialogHeader>
-                              <AlertDialogFooter>
-                                <AlertDialogCancel>Cancelar</AlertDialogCancel>
-                                <AlertDialogAction
-                                  onClick={() => handleDelete(app.id)}
-                                  className="bg-destructive hover:bg-destructive/90"
-                                >
-                                  Excluir
-                                </AlertDialogAction>
-                              </AlertDialogFooter>
-                            </AlertDialogContent>
-                          </AlertDialog>
+                            </div>
+                          </SmartModal>
                         </div>
                       </div>
 

--- a/src/components/patients/PatientTable.tsx
+++ b/src/components/patients/PatientTable.tsx
@@ -14,17 +14,7 @@ import { FilePenLine, Trash2, Eye, PlusCircle } from "lucide-react";
 import Link from "next/link";
 import { PatientFormDialog } from "./PatientFormDialog";
 import { useState } from "react";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog";
+import { SmartModal } from "@/components/SmartModal";
 import { useToast } from "@/hooks/use-toast";
 import { format, differenceInYears, parseISO } from 'date-fns';
 
@@ -37,6 +27,7 @@ interface PatientTableProps {
 export function PatientTable({ patients, onUpdatePatient, onDeletePatient }: PatientTableProps) {
   const [editingPatient, setEditingPatient] = useState<Patient | null>(null);
   const [isFormOpen, setIsFormOpen] = useState(false);
+  const [toDelete, setToDelete] = useState<Patient | null>(null);
   const { toast } = useToast();
 
   const handleEdit = (patient: Patient) => {
@@ -107,28 +98,37 @@ export function PatientTable({ patients, onUpdatePatient, onDeletePatient }: Pat
                   <FilePenLine className="h-4 w-4" />
                   <span className="sr-only">Editar</span>
                 </Button>
-                 <AlertDialog>
-                  <AlertDialogTrigger asChild>
-                    <Button variant="ghost" size="icon" className="text-destructive hover:text-destructive/80">
-                      <Trash2 className="h-4 w-4" />
-                      <span className="sr-only">Excluir</span>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="text-destructive hover:text-destructive/80"
+                  onClick={() => setToDelete(patient)}
+                >
+                  <Trash2 className="h-4 w-4" />
+                  <span className="sr-only">Excluir</span>
+                </Button>
+                <SmartModal
+                  id="delete-patient"
+                  open={toDelete?.id === patient.id}
+                  onClose={() => setToDelete(null)}
+                  title="Confirmar Exclusão"
+                >
+                  <p className="text-sm">
+                    Tem certeza que deseja excluir o paciente {patient.name}? Esta ação não pode ser desfeita.
+                  </p>
+                  <div className="mt-4 flex justify-end gap-2">
+                    <Button onClick={() => setToDelete(null)}>Cancelar</Button>
+                    <Button
+                      variant="destructive"
+                      onClick={() => {
+                        handleDelete(patient.id);
+                        setToDelete(null);
+                      }}
+                    >
+                      Excluir
                     </Button>
-                  </AlertDialogTrigger>
-                  <AlertDialogContent>
-                    <AlertDialogHeader>
-                      <AlertDialogTitle>Confirmar Exclusão</AlertDialogTitle>
-                      <AlertDialogDescription>
-                        Tem certeza que deseja excluir o paciente {patient.name}? Esta ação não pode ser desfeita.
-                      </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                      <AlertDialogCancel>Cancelar</AlertDialogCancel>
-                      <AlertDialogAction onClick={() => handleDelete(patient.id)} className="bg-destructive hover:bg-destructive/90">
-                        Excluir
-                      </AlertDialogAction>
-                    </AlertDialogFooter>
-                  </AlertDialogContent>
-                </AlertDialog>
+                  </div>
+                </SmartModal>
               </TableCell>
             </TableRow>
           ))}

--- a/src/components/tasks/TaskTable.tsx
+++ b/src/components/tasks/TaskTable.tsx
@@ -12,7 +12,8 @@ import {
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { FilePenLine, Trash2, CheckSquare } from "lucide-react";
-import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "@/components/ui/alert-dialog";
+import { SmartModal } from "@/components/SmartModal";
+import { useState } from "react";
 import { format } from "date-fns";
 
 interface TaskTableProps {
@@ -33,6 +34,8 @@ export function TaskTable({ tasks, onEdit, onDelete, onToggleStatus }: TaskTable
         return "secondary";
     }
   };
+
+  const [toDelete, setToDelete] = useState<Task | null>(null);
 
   return (
     <Table>
@@ -84,25 +87,35 @@ export function TaskTable({ tasks, onEdit, onDelete, onToggleStatus }: TaskTable
                 <FilePenLine className="h-4 w-4" />
                 <span className="sr-only">Editar</span>
               </Button>
-              <AlertDialog>
-                <AlertDialogTrigger asChild>
-                  <Button variant="ghost" size="icon" className="text-destructive hover:text-destructive/80">
-                    <Trash2 className="h-4 w-4" />
-                    <span className="sr-only">Excluir</span>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="text-destructive hover:text-destructive/80"
+                onClick={() => setToDelete(task)}
+              >
+                <Trash2 className="h-4 w-4" />
+                <span className="sr-only">Excluir</span>
+              </Button>
+              <SmartModal
+                id="delete-task"
+                open={toDelete?.id === task.id}
+                onClose={() => setToDelete(null)}
+                title="Confirmar Exclusão"
+              >
+                <p className="text-sm">Tem certeza que deseja excluir esta tarefa?</p>
+                <div className="mt-4 flex justify-end gap-2">
+                  <Button onClick={() => setToDelete(null)}>Cancelar</Button>
+                  <Button
+                    variant="destructive"
+                    onClick={() => {
+                      onDelete(task.id);
+                      setToDelete(null);
+                    }}
+                  >
+                    Excluir
                   </Button>
-                </AlertDialogTrigger>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>Confirmar Exclusão</AlertDialogTitle>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel>Cancelar</AlertDialogCancel>
-                    <AlertDialogAction onClick={() => onDelete(task.id)} className="bg-destructive hover:bg-destructive/90">
-                      Excluir
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
+                </div>
+              </SmartModal>
             </TableCell>
           </TableRow>
         ))}

--- a/src/components/templates/TemplateTable.tsx
+++ b/src/components/templates/TemplateTable.tsx
@@ -12,17 +12,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { FilePenLine, Trash2 } from "lucide-react";
 import { useState } from "react";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog";
+import { SmartModal } from "@/components/SmartModal";
 import { useToast } from "@/hooks/use-toast";
 import { TemplateFormDialog } from "./TemplateFormDialog";
 
@@ -35,6 +25,7 @@ interface TemplateTableProps {
 export function TemplateTable({ templates, onSave, onDelete }: TemplateTableProps) {
   const [editing, setEditing] = useState<Template | null>(null);
   const [isFormOpen, setIsFormOpen] = useState(false);
+  const [toDelete, setToDelete] = useState<Template | null>(null);
   const { toast } = useToast();
 
   const handleEdit = (template: Template) => {
@@ -93,28 +84,35 @@ export function TemplateTable({ templates, onSave, onDelete }: TemplateTableProp
                   <FilePenLine className="h-4 w-4" />
                   <span className="sr-only">Editar</span>
                 </Button>
-                <AlertDialog>
-                  <AlertDialogTrigger asChild>
-                    <Button variant="ghost" size="icon" className="text-destructive hover:text-destructive/80">
-                      <Trash2 className="h-4 w-4" />
-                      <span className="sr-only">Excluir</span>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="text-destructive hover:text-destructive/80"
+                  onClick={() => setToDelete(tpl)}
+                >
+                  <Trash2 className="h-4 w-4" />
+                  <span className="sr-only">Excluir</span>
+                </Button>
+                <SmartModal
+                  id="delete-template"
+                  open={toDelete?.id === tpl.id}
+                  onClose={() => setToDelete(null)}
+                  title="Confirmar Exclusão"
+                >
+                  <p className="text-sm">Tem certeza que deseja excluir o modelo {tpl.name}?</p>
+                  <div className="mt-4 flex justify-end gap-2">
+                    <Button onClick={() => setToDelete(null)}>Cancelar</Button>
+                    <Button
+                      variant="destructive"
+                      onClick={() => {
+                        handleDelete(tpl.id, tpl.name);
+                        setToDelete(null);
+                      }}
+                    >
+                      Excluir
                     </Button>
-                  </AlertDialogTrigger>
-                  <AlertDialogContent>
-                    <AlertDialogHeader>
-                      <AlertDialogTitle>Confirmar Exclusão</AlertDialogTitle>
-                      <AlertDialogDescription>
-                        Tem certeza que deseja excluir o modelo {tpl.name}?
-                      </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                      <AlertDialogCancel>Cancelar</AlertDialogCancel>
-                      <AlertDialogAction onClick={() => handleDelete(tpl.id, tpl.name)} className="bg-destructive hover:bg-destructive/90">
-                        Excluir
-                      </AlertDialogAction>
-                    </AlertDialogFooter>
-                  </AlertDialogContent>
-                </AlertDialog>
+                  </div>
+                </SmartModal>
               </TableCell>
             </TableRow>
           ))}

--- a/src/components/waitlist/WaitlistTable.tsx
+++ b/src/components/waitlist/WaitlistTable.tsx
@@ -10,20 +10,11 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
-import { CalendarPlus, Trash2, Edit } from "lucide-react"; // CalendarPlus for scheduling
+import { CalendarPlus, Trash2 } from "lucide-react"; // CalendarPlus for scheduling
 import { format, parseISO } from "date-fns";
 import { ptBR } from "date-fns/locale";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog";
+import { SmartModal } from "@/components/SmartModal";
+import { useState } from "react";
 import { useToast } from "@/hooks/use-toast";
 import { useRouter } from "next/navigation";
 
@@ -37,6 +28,7 @@ interface WaitlistTableProps {
 export function WaitlistTable({ items, onDeleteItem }: WaitlistTableProps) {
   const { toast } = useToast();
   const router = useRouter();
+  const [toDelete, setToDelete] = useState<WaitingListItem | null>(null);
 
   const handleDelete = (itemId: string, patientName: string) => {
     onDeleteItem(itemId);
@@ -93,28 +85,37 @@ export function WaitlistTable({ items, onDeleteItem }: WaitlistTableProps) {
               {/* <Button variant="ghost" size="icon" className="mr-2 text-blue-600 hover:text-blue-500">
                 <Edit className="h-4 w-4" />
               </Button> */}
-              <AlertDialog>
-                  <AlertDialogTrigger asChild>
-                    <Button variant="ghost" size="icon" className="text-destructive hover:text-destructive/80">
-                      <Trash2 className="h-4 w-4" />
-                      <span className="sr-only">Excluir</span>
-                    </Button>
-                  </AlertDialogTrigger>
-                  <AlertDialogContent>
-                    <AlertDialogHeader>
-                      <AlertDialogTitle>Confirmar Exclusão</AlertDialogTitle>
-                      <AlertDialogDescription>
-                        Tem certeza que deseja remover {item.patientName} da lista de espera?
-                      </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                      <AlertDialogCancel>Cancelar</AlertDialogCancel>
-                      <AlertDialogAction onClick={() => handleDelete(item.id, item.patientName)} className="bg-destructive hover:bg-destructive/90">
-                        Excluir
-                      </AlertDialogAction>
-                    </AlertDialogFooter>
-                  </AlertDialogContent>
-                </AlertDialog>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="text-destructive hover:text-destructive/80"
+                onClick={() => setToDelete(item)}
+              >
+                <Trash2 className="h-4 w-4" />
+                <span className="sr-only">Excluir</span>
+              </Button>
+              <SmartModal
+                id="delete-wait-item"
+                open={toDelete?.id === item.id}
+                onClose={() => setToDelete(null)}
+                title="Confirmar Exclusão"
+              >
+                <p className="text-sm">
+                  Tem certeza que deseja remover {item.patientName} da lista de espera?
+                </p>
+                <div className="mt-4 flex justify-end gap-2">
+                  <Button onClick={() => setToDelete(null)}>Cancelar</Button>
+                  <Button
+                    variant="destructive"
+                    onClick={() => {
+                      handleDelete(item.id, item.patientName);
+                      setToDelete(null);
+                    }}
+                  >
+                    Excluir
+                  </Button>
+                </div>
+              </SmartModal>
             </TableCell>
           </TableRow>
         ))}


### PR DESCRIPTION
## Summary
- add overlay click handler to `SmartModal`
- replace AlertDialog deletion prompts with `SmartModal`
- fix unclosed component in `AppLayout`

## Testing
- `npm run lint` *(fails: interactive prompt)*
- `npm run typecheck` *(fails: missing modules)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68433ff493cc83249a26a7b96e7ffafd