### PR TITLE
Fix import syntax and stray closing lines

### DIFF
--- a/src/components/patients/PatientDetailsClient.tsx
+++ b/src/components/patients/PatientDetailsClient.tsx
@@ -121,9 +121,6 @@ const handleSavePatient = (updatedPatient: Patient) => {
   });
 };
 
-    });
-  };
-
   if (isLoading) {
     return (
       <div className="flex justify-center items-center h-64">

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -1,5 +1,5 @@
 
-import { format, addDays } from "date-fns";
+import { format, addDays } from 'date-fns';
 import type {
   Patient,
   Appointment,
@@ -11,7 +11,6 @@ import type {
   FinanceRecord,
   Medication,
   SymptomHeatmapEntry,
-import {
   FormulationDiagram,
   // outros tipos aqui
 } from '@/lib/types';


### PR DESCRIPTION
## Summary
- fix incorrect import block in mock-data
- remove stray closing lines in PatientDetailsClient

## Testing
- `npm test`
- `npm run typecheck` *(fails: Property 'document' does not exist on type ...)*

------
https://chatgpt.com/codex/tasks/task_e_68434c10bb148324a14b4289a626ffbc