### PR TITLE
Add automated reminders via email and SMS

### DIFF
--- a/functions/scheduleAppointmentReminder.ts
+++ b/functions/scheduleAppointmentReminder.ts
@@ -1,0 +1,57 @@
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin';
+import sgMail from '@sendgrid/mail';
+import twilio from 'twilio';
+
+admin.initializeApp();
+const db = admin.firestore();
+
+sgMail.setApiKey(process.env.SENDGRID_API_KEY as string);
+const twilioClient = twilio(process.env.TWILIO_SID as string, process.env.TWILIO_AUTH_TOKEN as string);
+
+const SENDGRID_FROM = process.env.SENDGRID_FROM_EMAIL as string;
+const TWILIO_SMS_FROM = process.env.TWILIO_SMS_FROM;
+
+const MINUTES_BEFORE_24H = 24 * 60; // 24 hours
+const MINUTES_BEFORE_30M = 30; // 30 minutes
+
+async function notifyPatient(patientId: string, message: string) {
+  const patientSnap = await db.doc(`patients/${patientId}`).get();
+  const patient = patientSnap.data() as any;
+  if (!patient) return;
+  const contact = patient.contact;
+  if (contact) {
+    if (contact.includes('@')) {
+      await sgMail.send({ to: contact, from: SENDGRID_FROM, subject: 'Lembrete de Sessão', text: message });
+    } else if (TWILIO_SMS_FROM) {
+      await twilioClient.messages.create({ from: TWILIO_SMS_FROM, to: contact, body: message });
+    }
+  }
+}
+
+async function processReminders(minutesBefore: number, flag: string) {
+  const now = Date.now();
+  const targetStart = new Date(now + (minutesBefore - 1) * 60 * 1000).toISOString();
+  const targetEnd = new Date(now + minutesBefore * 60 * 1000).toISOString();
+  const snap = await db
+    .collection('appointments')
+    .where('status', '==', 'pending')
+    .where('dateTime', '>=', targetStart)
+    .where('dateTime', '<=', targetEnd)
+    .get();
+
+  for (const docSnap of snap.docs) {
+    const data = docSnap.data() as any;
+    if (data[flag]) continue;
+    const message = `Lembrete: você tem uma sessão agendada para ${data.dateTime}`;
+    await notifyPatient(data.patientId, message);
+    await docSnap.ref.update({ [flag]: true });
+  }
+}
+
+export const scheduleAppointmentReminder = functions.pubsub
+  .schedule('* * * * *')
+  .onRun(async () => {
+    await processReminders(MINUTES_BEFORE_24H, 'reminder24hSent');
+    await processReminders(MINUTES_BEFORE_30M, 'reminder30mSent');
+  });

--- a/functions/scheduleAssessmentReminder.ts
+++ b/functions/scheduleAssessmentReminder.ts
@@ -1,0 +1,46 @@
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin';
+import sgMail from '@sendgrid/mail';
+import twilio from 'twilio';
+
+admin.initializeApp();
+const db = admin.firestore();
+
+sgMail.setApiKey(process.env.SENDGRID_API_KEY as string);
+const twilioClient = twilio(process.env.TWILIO_SID as string, process.env.TWILIO_AUTH_TOKEN as string);
+
+const SENDGRID_FROM = process.env.SENDGRID_FROM_EMAIL as string;
+const TWILIO_SMS_FROM = process.env.TWILIO_SMS_FROM;
+
+const HOURS_AFTER = parseInt(process.env.ASSESSMENT_REMINDER_HOURS || '24');
+
+async function notify(patientId: string, message: string) {
+  const snap = await db.doc(`patients/${patientId}`).get();
+  const patient = snap.data() as any;
+  if (!patient) return;
+  const contact = patient.contact;
+  if (contact) {
+    if (contact.includes('@')) {
+      await sgMail.send({ to: contact, from: SENDGRID_FROM, subject: 'Lembrete de Inventário', text: message });
+    } else if (TWILIO_SMS_FROM) {
+      await twilioClient.messages.create({ from: TWILIO_SMS_FROM, to: contact, body: message });
+    }
+  }
+}
+
+export const scheduleAssessmentReminder = functions.pubsub
+  .schedule('every 60 minutes')
+  .onRun(async () => {
+    const cutoff = admin.firestore.Timestamp.fromMillis(Date.now() - HOURS_AFTER * 60 * 60 * 1000);
+    const snap = await db
+      .collectionGroup('assessments')
+      .where('status', '==', 'pending')
+      .where('createdAt', '<=', cutoff)
+      .get();
+
+    for (const docSnap of snap.docs) {
+      const patientId = docSnap.ref.parent.parent?.id;
+      if (!patientId) continue;
+      await notify(patientId, 'Você possui um inventário pendente para preenchimento.');
+    }
+  });

--- a/functions/scheduleTaskReminder.ts
+++ b/functions/scheduleTaskReminder.ts
@@ -1,8 +1,15 @@
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
+import sgMail from '@sendgrid/mail';
+import twilio from 'twilio';
 
 admin.initializeApp();
 const db = admin.firestore();
+
+sgMail.setApiKey(process.env.SENDGRID_API_KEY as string);
+const twilioClient = twilio(process.env.TWILIO_SID as string, process.env.TWILIO_AUTH_TOKEN as string);
+const SENDGRID_FROM = process.env.SENDGRID_FROM_EMAIL as string;
+const TWILIO_SMS_FROM = process.env.TWILIO_SMS_FROM;
 
 const MINUTES_BEFORE = parseInt(process.env.TASK_REMINDER_MINUTES || '10');
 
@@ -12,6 +19,27 @@ async function send(uid: string, taskId: string, title: string) {
     notification: { title: 'Tarefa próxima', body: title },
     data: { taskId },
   });
+
+  try {
+    const user = await admin.auth().getUser(uid);
+    if (user.email) {
+      await sgMail.send({
+        to: user.email,
+        from: SENDGRID_FROM,
+        subject: 'Lembrete de Tarefa',
+        text: `Você possui a tarefa "${title}" com vencimento em breve.`,
+      });
+    }
+    if (user.phoneNumber && TWILIO_SMS_FROM) {
+      await twilioClient.messages.create({
+        from: TWILIO_SMS_FROM,
+        to: user.phoneNumber,
+        body: `Tarefa pendente: ${title}`,
+      });
+    }
+  } catch (e) {
+    console.error('Erro ao enviar email/SMS', e);
+  }
 }
 
 export const scheduleTaskReminder = functions.pubsub


### PR DESCRIPTION
## Summary
- add scheduled function to notify patients about upcoming appointments
- add scheduled function reminding about unfinished assessments
- extend task reminder to also send e-mail and SMS notifications

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: multiple type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6843580bec508324b3100601127100af