### PR TITLE
Add responsive viewport meta tag

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,6 +20,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=PT+Sans:wght@400;700&display=swap" rel="stylesheet" />


### PR DESCRIPTION
## Summary
- improve responsive behaviour with a viewport meta tag in the root layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843653a17ec83249b744fc6b6730e16