### PR TITLE
Implement global Image fallback

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -27,7 +27,7 @@ import {
   mockFinanceRecords,
 } from "@/lib/mock-data";
 import { startOfWeek, endOfWeek, isSameDay, differenceInCalendarDays } from "date-fns";
-import Image from "next/image";
+import CustomImage from "@/components/ui/custom-image";
 
 export default function DashboardPage() {
   const { user, isLoading } = useAuth();
@@ -80,7 +80,7 @@ export default function DashboardPage() {
           <h1 className="text-3xl font-bold font-headline text-primary">Bem-vindo(a), {user.name}!</h1>
           <p className="text-muted-foreground mt-1">Aqui está um resumo da sua atividade recente.</p>
         </div>
-        <Image
+        <CustomImage
           src={user.profileImage || "https://placehold.co/100x100?text=Foto"}
           alt={`Foto de perfil de ${user.name}`}
           width={100}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,6 +23,7 @@ export default function RootLayout({
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=PT+Sans:wght@400;700&display=swap" rel="stylesheet" />
+        <link rel="icon" href="/favicon.ico" />
       </head>
       <body className="font-body antialiased">
         {/* Envolva o conteúdo principal com TooltipProvider */}

--- a/src/components/dashboard/WelcomeCard.tsx
+++ b/src/components/dashboard/WelcomeCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Image from 'next/image';
+import CustomImage from '@/components/ui/custom-image';
 import { useAuth } from '@/contexts/AuthContext';
 import { useBannerImage } from '@/hooks/useBannerImage';
 
@@ -23,7 +23,7 @@ export default function WelcomeCard() {
         <p className="text-muted-foreground mt-1">Aqui está um resumo da sua atividade recente.</p>
       </div>
       {banner && (
-        <Image
+        <CustomImage
           src={banner}
           alt="Banner"
           width={300}

--- a/src/components/patients/PatientDetailsClient.tsx
+++ b/src/components/patients/PatientDetailsClient.tsx
@@ -15,7 +15,7 @@ import { useToast } from "@/hooks/use-toast";
 import { usePatientAssessments } from "@/hooks/usePatientAssessments";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
-import Image from "next/image";
+import CustomImage from "@/components/ui/custom-image";
 
 interface PatientDetailsClientProps {
   patientId: string;
@@ -155,7 +155,7 @@ const handleSavePatient = (updatedPatient: Patient) => {
       <Card className="shadow-xl rounded-lg overflow-hidden">
         <div className="md:flex">
           <div className="md:w-1/3 bg-gradient-to-br from-primary/20 to-accent/20 p-6 flex flex-col items-center justify-center text-center">
-            <Image
+            <CustomImage
               src={`https://placehold.co/150x150.png?text=${patient.name.charAt(0)}`}
               alt={patient.name}
               width={120}

--- a/src/components/ui/custom-image.tsx
+++ b/src/components/ui/custom-image.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import Image, { type ImageProps } from "next/image";
+import { useState } from "react";
+
+export interface CustomImageProps extends ImageProps {
+  fallbackSrc?: string;
+}
+
+export default function CustomImage({
+  src,
+  fallbackSrc = "/favicon.ico",
+  ...props
+}: CustomImageProps) {
+  const [imgSrc, setImgSrc] = useState(src);
+
+  return (
+    <Image
+      {...props}
+      src={imgSrc}
+      onError={() => setImgSrc(fallbackSrc)}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add global favicon link in `RootLayout`
- create a `CustomImage` wrapper component to load a fallback image
- use `CustomImage` instead of `next/image` across dashboard and patient components

## Testing
- `npm run lint` *(fails: prompts ESLint setup)*
- `npm run typecheck` *(fails: TS errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843654d506883248c24d1aab73851bc