### PR TITLE
Simplify layout markup

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -5,7 +5,6 @@ import { useRouter } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
 import Sidebar from '@/components/layout/Sidebar';
 import { AppHeader } from '@/components/layout/Header';
-import { SidebarProvider } from '@/components/ui/sidebar';
 
 
 export default function AppLayout({
@@ -23,7 +22,6 @@ export default function AppLayout({
   }, [isAuthenticated, isLoading, router]);
 
   if (isLoading || !isAuthenticated) {
-    // You can render a loading spinner here
     return (
       <div className="flex min-h-screen items-center justify-center">
         <p>Carregando...</p>
@@ -40,9 +38,6 @@ export default function AppLayout({
           {children}
         </main>
       </div>
-      <SidebarProvider defaultOpen={true}>
-        {/* Assuming RightSidebar content will be handled within the main content or a different component */}
-      </SidebarProvider>
     </div>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,23 +20,20 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<head>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-  <link
-    href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=PT+Sans:wght@400;700&display=swap"
-    rel="stylesheet"
-  />
-  <link rel="icon" href="/favicon.ico" />
-</head>
-
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=PT+Sans:wght@400;700&display=swap" rel="stylesheet" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
+        />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=PT+Sans:wght@400;700&display=swap"
+          rel="stylesheet"
+        />
+        <link rel="icon" href="/favicon.ico" />
       </head>
       <body className="font-body antialiased min-h-screen bg-background">
-        {/* Envolva o conteúdo principal com TooltipProvider */}
         <TooltipProvider>
           <ThemeProvider>
             <AuthProvider>


### PR DESCRIPTION
## Summary
- remove unused sidebar provider
- eliminate duplicate `<head>` elements and tidy up HTML

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684380463eb08324b2de019fa0761f2c