### PR TITLE
Fix menu hook localStorage access

### DIFF
--- a/src/lib/use-smart-menu/useSmartMenu.ts
+++ b/src/lib/use-smart-menu/useSmartMenu.ts
@@ -4,7 +4,10 @@ import type { SmartMenuConfig } from './types';
 
 export function useSmartMenu(config: SmartMenuConfig) {
   const { id, animation, restoreFocus = true, persistFocus = true } = config;
-  const [open, setOpen] = useState(() => localStorage.getItem(`menu:${id}`) === 'true');
+  const [open, setOpen] = useState(() => {
+    if (typeof window === 'undefined') return false
+    return localStorage.getItem(`menu:${id}`) === 'true'
+  })
   const ref = useRef<HTMLElement>(null);
 
   const toggle = () => {


### PR DESCRIPTION
## Summary
- avoid `localStorage` access at build time

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684381fc113c832481c18bbc3edc8510