### PR TITLE
Implement user approval roles

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -12,7 +12,7 @@ export default function AppLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const { isAuthenticated, isLoading } = useAuth();
+  const { isAuthenticated, isLoading, user } = useAuth();
   const router = useRouter();
 
   useEffect(() => {
@@ -25,6 +25,14 @@ export default function AppLayout({
     return (
       <div className="flex min-h-screen items-center justify-center">
         <p>Carregando...</p>
+      </div>
+    );
+  }
+
+  if (user && !user.isApproved) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p>Aguardando aprovação do administrador...</p>
       </div>
     );
   }

--- a/src/app/(app)/user-approvals/page.tsx
+++ b/src/app/(app)/user-approvals/page.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import { db } from "@/lib/firebaseClient";
+import { collection, onSnapshot, query, where, updateDoc, doc } from "firebase/firestore";
+import { User } from "@/lib/types";
+import { UserApprovalTable } from "@/components/admin/UserApprovalTable";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useToast } from "@/hooks/use-toast";
+
+export default function UserApprovalsPage() {
+  const { user } = useAuth();
+  const [pending, setPending] = useState<User[]>([]);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    const q = query(collection(db, "users"), where("isApproved", "==", false));
+    const unsub = onSnapshot(q, (snap) => {
+      const data = snap.docs.map((d) => ({ id: d.id, ...(d.data() as any) })) as User[];
+      setPending(data);
+    });
+    return () => unsub();
+  }, []);
+
+  const handleApprove = async (id: string) => {
+    await updateDoc(doc(db, "users", id), { isApproved: true });
+    toast({ title: "Usuário aprovado" });
+  };
+
+  if (!user || user.role !== "ADMIN") {
+    return <p className="p-8">Sem acesso.</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold font-headline">Aprovar Usuários</h1>
+      <Card className="shadow-lg rounded-lg">
+        <CardHeader>
+          <CardTitle>Pendentes</CardTitle>
+          <CardDescription>{pending.length} usuário(s) aguardando aprovação.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <UserApprovalTable users={pending} onApprove={handleApprove} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -32,7 +32,7 @@ const mockRegisterUser = async (
 export default function RegisterPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [role, setRole] = useState('Psicólogo'); // Default role matches UserRole
+  const [role, setRole] = useState('PSYCHOLOGIST'); // Default role
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState(false);
@@ -93,7 +93,7 @@ export default function RegisterPage() {
                 <SelectValue placeholder="Selecione o tipo de usuário" />
               </SelectTrigger>
               <SelectContent>
-              <SelectItem value="Psicólogo">Psicólogo</SelectItem>
+              <SelectItem value="PSYCHOLOGIST">Psicólogo</SelectItem>
                 {/* Add other roles as needed in the future */}
                 {/* <SelectItem value="admin_global">Admin Global</SelectItem> */}
                 {/* <SelectItem value="admin_secretario">Admin/Secretário</SelectItem> */}

--- a/src/components/admin/UserApprovalTable.tsx
+++ b/src/components/admin/UserApprovalTable.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import type { User } from "@/lib/types";
+import {
+  Table,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Check } from "lucide-react";
+
+interface Props {
+  users: User[];
+  onApprove: (id: string) => void;
+}
+
+export function UserApprovalTable({ users, onApprove }: Props) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Nome</TableHead>
+          <TableHead>Email</TableHead>
+          <TableHead>Papel</TableHead>
+          <TableHead className="text-right">Ações</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {users.length === 0 && (
+          <TableRow>
+            <TableCell colSpan={4} className="text-center h-24">
+              Nenhum usuário pendente.
+            </TableCell>
+          </TableRow>
+        )}
+        {users.map((u) => (
+          <TableRow key={u.id}>
+            <TableCell>{u.name}</TableCell>
+            <TableCell>{u.email}</TableCell>
+            <TableCell>{u.role}</TableCell>
+            <TableCell className="text-right">
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => onApprove(u.id)}
+                title="Aprovar"
+              >
+                <Check className="h-4 w-4" />
+                <span className="sr-only">Aprovar</span>
+              </Button>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -26,37 +26,41 @@ import { cn } from '@/lib/utils';
 import { motion } from 'framer-motion';
 import { useSmartMenu } from '@/lib/use-smart-menu';
 
-const sections = [
-  {
-    title: 'Consultório',
-    items: [
-      { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
-      { href: '/patients', label: 'Pacientes', icon: Users },
-      { href: '/appointments', label: 'Agendamentos', icon: CalendarDays },
-      { href: '/waiting-list', label: 'Lista de Espera', icon: ListChecks },
-    ],
-  },
-  {
-    title: 'Ferramentas',
-    items: [
-      { href: '/templates', label: 'Modelos', icon: FileText },
-      { href: '/medications', label: 'Guia Rápido', icon: Pill },
-      { href: '/self-care', label: 'Saúde Mental', icon: HeartPulse },
-      { href: '/knowledge-base', label: 'Base de Conhecimento', icon: BookOpenCheck },
-      { href: '/analytics', label: 'Tendências', icon: LineChart },
-    ],
-  },
-  {
-    title: 'Sistema',
-    items: [
-      { href: '/settings', label: 'Configurações', icon: Settings },
-    ],
-  },
-];
-
 function SidebarContent({ className, onNavigate }: { className?: string; onNavigate?: () => void }) {
   const pathname = usePathname();
   const { logout, user } = useAuth();
+
+  const sections = [
+    {
+      title: 'Consultório',
+      items: [
+        { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
+        { href: '/patients', label: 'Pacientes', icon: Users },
+        { href: '/appointments', label: 'Agendamentos', icon: CalendarDays },
+        { href: '/waiting-list', label: 'Lista de Espera', icon: ListChecks },
+      ],
+    },
+    {
+      title: 'Ferramentas',
+      items: [
+        { href: '/templates', label: 'Modelos', icon: FileText },
+        { href: '/medications', label: 'Guia Rápido', icon: Pill },
+        { href: '/self-care', label: 'Saúde Mental', icon: HeartPulse },
+        { href: '/knowledge-base', label: 'Base de Conhecimento', icon: BookOpenCheck },
+        { href: '/analytics', label: 'Tendências', icon: LineChart },
+      ],
+    },
+    {
+      title: 'Sistema',
+      items: [
+        { href: '/settings', label: 'Configurações', icon: Settings },
+        ...(user?.role === 'ADMIN'
+          ? [{ href: '/user-approvals', label: 'Aprovar Usuários', icon: Users }]
+          : []),
+      ],
+    },
+  ];
+
   const [openSections, setOpenSections] = useState<Record<string, boolean>>(() =>
     sections.reduce((acc, s) => {
       acc[s.title] = true;

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -6,7 +6,8 @@ import { mockUser } from '@/lib/mock-data';
 import { useRouter } from 'next/navigation';
 import type { ReactNode } from 'react';
 import React, { createContext, useContext, useState, useEffect } from 'react';
-import { auth } from '@/lib/firebaseClient';
+import { auth, db } from '@/lib/firebaseClient';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
 import {
   GoogleAuthProvider,
   signInWithPopup,
@@ -31,16 +32,25 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const router = useRouter();
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (fbUser) => {
+    const unsubscribe = onAuthStateChanged(auth, async (fbUser) => {
       if (fbUser) {
-        const mappedUser: User = {
-          id: fbUser.uid,
-          name: fbUser.displayName || '',
-          email: fbUser.email || '',
-          role: 'Psicólogo',
-        };
-        setUser(mappedUser);
-        localStorage.setItem('psiguard_user', JSON.stringify(mappedUser));
+        try {
+          const snap = await getDoc(doc(db, 'users', fbUser.uid));
+          const data = snap.data() as Partial<User> | undefined;
+          const mappedUser: User = {
+            id: fbUser.uid,
+            name: fbUser.displayName || '',
+            email: fbUser.email || '',
+            role: (data?.role as User['role']) || 'PSYCHOLOGIST',
+            isApproved: data?.isApproved ?? false,
+            profileImage: fbUser.photoURL || undefined,
+          };
+          setUser(mappedUser);
+          localStorage.setItem('psiguard_user', JSON.stringify(mappedUser));
+        } catch (err) {
+          console.error('Failed to load user profile', err);
+          setUser(null);
+        }
       } else {
         const storedUser = localStorage.getItem('psiguard_user');
         if (storedUser) {
@@ -63,6 +73,16 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     if (email === mockUser.email) {
       setUser(mockUser);
       localStorage.setItem('psiguard_user', JSON.stringify(mockUser));
+      try {
+        await setDoc(doc(db, 'users', mockUser.id), {
+          role: mockUser.role,
+          isApproved: true,
+          name: mockUser.name,
+          email: mockUser.email,
+        }, { merge: true });
+      } catch (err) {
+        console.error('Failed to save mock user', err);
+      }
       router.push('/dashboard');
     } else {
       // Basic error handling - in a real app, show a toast or error message
@@ -80,11 +100,22 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       const provider = new GoogleAuthProvider();
       const result = await signInWithPopup(auth, provider);
       const fbUser = result.user;
+      let data: Partial<User> | undefined;
+      const ref = doc(db, 'users', fbUser.uid);
+      const snap = await getDoc(ref);
+      if (!snap.exists()) {
+        data = { role: 'PSYCHOLOGIST', isApproved: false };
+        await setDoc(ref, data);
+      } else {
+        data = snap.data() as Partial<User>;
+      }
       const mappedUser: User = {
         id: fbUser.uid,
         name: fbUser.displayName || '',
         email: fbUser.email || '',
-        role: 'Psicólogo',
+        role: (data?.role as User['role']) || 'PSYCHOLOGIST',
+        isApproved: data?.isApproved ?? false,
+        profileImage: fbUser.photoURL || undefined,
       };
       setUser(mappedUser);
       localStorage.setItem('psiguard_user', JSON.stringify(mappedUser));

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -20,7 +20,8 @@ import type {
 export const mockUser: User = {
   id: 'user-psychologist-01',
   email: 'doctor.jane@psiguard.com',
-  role: 'Psicólogo',
+  role: 'PSYCHOLOGIST',
+  isApproved: true,
   name: 'Dr. Jane Doe',
   profileImage: 'https://placehold.co/100x100?text=JD',
 };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,5 @@
 // 🔐 Papéis disponíveis no sistema
-export type UserRole = 'Admin Global' | 'Psicólogo' | 'Admin/Secretário';
+export type UserRole = 'ADMIN' | 'PSYCHOLOGIST' | 'RECEPCAO' | 'AGENDAMENTO';
 
 // 🩺 Status possíveis de um agendamento
 export type AttendanceStatus = 'pending' | 'present' | 'absent' | 'rescheduled';
@@ -10,6 +10,7 @@ export interface User {
   name: string;
   email: string;
   role: UserRole;
+  isApproved: boolean;
   profileImage?: string;
 }
 


### PR DESCRIPTION
## Summary
- add role types and approval flag
- update mock data to include approval
- load role/isApproved from Firestore in AuthContext
- block access until approval in main layout
- add admin link and table to approve users
- add admin user approval page
- adapt registration defaults

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438230da08832490af05e8c67d195c