### PR TITLE
Implement patient data encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,6 @@ NEXT_PUBLIC_FIREBASE_APP_ID=your_app_id
 # 🔐 Chave de criptografia AES-256-GCM (32 bytes base64). 
 # NÃO use esta chave em produção!
 CRYPTO_SECRET_KEY=REPLACE_ME_BASE64_32BYTES
+```
+
+Todos os dados de pacientes são criptografados no cliente usando AES antes de serem manipulados.

--- a/src/app/(app)/patients/[id]/page.tsx
+++ b/src/app/(app)/patients/[id]/page.tsx
@@ -13,6 +13,7 @@ import { db } from '@/lib/firebaseClient';
 import { addDoc, collection, updateDoc, doc, deleteDoc, serverTimestamp } from 'firebase/firestore';
 import type { Task } from '@/lib/types';
 import { useToast } from '@/hooks/use-toast';
+import { useAuth } from '@/contexts/AuthContext';
 
 interface PatientDetailPageProps {
   params: {
@@ -21,10 +22,15 @@ interface PatientDetailPageProps {
 }
 
 export default function PatientDetailPage({ params }: PatientDetailPageProps) {
+  const { user } = useAuth();
   const { tasks } = useTasks(params.id);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [editing, setEditing] = useState<Task | null>(null);
   const { toast } = useToast();
+
+  if (!user || user.role !== 'Psicólogo') {
+    return <p className="p-4">Acesso restrito aos psicólogos.</p>;
+  }
 
   const handleSave = async (data: Omit<Task, 'id' | 'createdAt' | 'updatedAt' | 'createdBy' | 'patientId'>) => {
     if (editing) {

--- a/src/app/(app)/patients/page.tsx
+++ b/src/app/(app)/patients/page.tsx
@@ -9,11 +9,17 @@ import { PlusCircle } from 'lucide-react';
 import { PatientFormDialog } from '@/components/patients/PatientFormDialog';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useToast } from "@/hooks/use-toast";
+import { useAuth } from "@/contexts/AuthContext";
 
 export default function PatientsPage() {
+  const { user } = useAuth();
   const [patients, setPatients] = useState<Patient[]>([]);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const { toast } = useToast();
+
+  if (!user || user.role !== 'Psicólogo') {
+    return <p className="p-4">Acesso restrito aos psicólogos.</p>;
+  }
 
   useEffect(() => {
     // Carrega lista de pacientes de exemplo

--- a/src/components/patients/PatientDetailsClient.tsx
+++ b/src/components/patients/PatientDetailsClient.tsx
@@ -179,6 +179,14 @@ const handleSavePatient = (updatedPatient: Patient) => {
                   <span className="font-semibold">Contato:</span> {patient.contact}
                 </div>
               </div>
+              {patient.cpf && (
+                <div className="flex items-center">
+                  <UserCircle className="h-5 w-5 mr-3 text-primary" />
+                  <div>
+                    <span className="font-semibold">CPF:</span> {patient.cpf}
+                  </div>
+                </div>
+              )}
               <div className="flex items-center">
                 <Gift className="h-5 w-5 mr-3 text-primary" />
                 <div>
@@ -258,8 +266,7 @@ const handleSavePatient = (updatedPatient: Patient) => {
               (LGPD/GDPR).
             </li>
             <li data-ai-hint="encryption reminder">
-              A criptografia client-side para campos sensíveis é uma prioridade de segurança (não
-              implementada neste protótipo).
+              Todos os dados de pacientes são criptografados localmente antes do armazenamento.
             </li>
             <li data-ai-hint="notification reminder">
               Notificações de sessão automáticas (24h e 30min antes) são funcionalidades planejadas.

--- a/src/components/patients/PatientFormDialog.tsx
+++ b/src/components/patients/PatientFormDialog.tsx
@@ -33,6 +33,7 @@ import React from 'react';
 const patientFormSchema = z.object({
   name: z.string().min(2, { message: "O nome deve ter pelo menos 2 caracteres." }),
   contact: z.string().min(5, { message: "Contato inválido." }), // Can be email or phone
+  cpf: z.string().length(11, { message: "CPF deve ter 11 dígitos." }),
   dateOfBirth: z.date({ required_error: "Data de nascimento é obrigatória." }),
 });
 
@@ -57,14 +58,14 @@ export function PatientFormDialog({ patient, onSave, children, isOpen: controlle
     resolver: zodResolver(patientFormSchema),
     defaultValues: patient
       ? { ...patient, dateOfBirth: patient.dateOfBirth ? parseISO(patient.dateOfBirth) : new Date() }
-      : { name: "", contact: "", dateOfBirth: undefined },
+      : { name: "", contact: "", cpf: "", dateOfBirth: undefined },
   });
   
   React.useEffect(() => {
     if (patient) {
       form.reset({ ...patient, dateOfBirth: patient.dateOfBirth ? parseISO(patient.dateOfBirth) : new Date() });
     } else {
-      form.reset({ name: "", contact: "", dateOfBirth: undefined });
+      form.reset({ name: "", contact: "", cpf: "", dateOfBirth: undefined });
     }
   }, [patient, form, isOpen]);
 
@@ -119,6 +120,19 @@ export function PatientFormDialog({ patient, onSave, children, isOpen: controlle
                   <FormLabel>Contato (Email/Telefone)</FormLabel>
                   <FormControl>
                     <Input placeholder="email@exemplo.com ou (XX) XXXXX-XXXX" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="cpf"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>CPF</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Somente números" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/src/components/patients/SessionNotesSection.tsx
+++ b/src/components/patients/SessionNotesSection.tsx
@@ -126,7 +126,7 @@ export function SessionNotesSection({
           <div className="mb-6 p-4 border rounded-md bg-card shadow">
             <h3 className="text-lg font-semibold mb-2">Nova Nota de Sessão</h3>
             <Textarea
-              placeholder="Digite as notas da sessão aqui... (Lembre-se da criptografia para dados sensíveis - não implementada no protótipo)"
+              placeholder="Digite as notas da sessão aqui..."
               value={newNote}
               onChange={(e) => setNewNote(e.target.value)}
               rows={5}

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -14,6 +14,7 @@ import type {
   FormulationDiagram,
   // outros tipos aqui
 } from '@/lib/types';
+import { encryptPatient, decryptPatient } from './patientCrypto';
 
 
 // 👤 Usuário mock
@@ -78,51 +79,43 @@ const initialSessionNotesP3: SessionNote[] = [
 
 // 👩‍⚕️ Pacientes mock
 export let mockPatients: Patient[] = [
-  {
+  encryptPatient({
     id: 'patient-001',
     name: 'Alice Wonderland',
-    contact: 'alice@example.com',
+    contact: '11999990001',
+    cpf: '12345678901',
     dateOfBirth: '1990-05-15',
     sessionNotes: initialSessionNotesP1,
-  },
-  {
+  }),
+  encryptPatient({
     id: 'patient-002',
     name: 'Bob The Builder',
-    contact: 'bob@example.com',
+    contact: '11999990002',
+    cpf: '98765432100',
     dateOfBirth: '1985-11-20',
     sessionNotes: initialSessionNotesP2,
-  },
-  {
+  }),
+  encryptPatient({
     id: 'patient-003',
     name: 'Charlie Brown',
-    contact: 'charlie@example.com',
+    contact: '11999990003',
+    cpf: '11122233344',
     dateOfBirth: '2000-02-10',
     sessionNotes: [],
-  },
-  {
+  }),
+  encryptPatient({
     id: 'patient-004',
     name: 'Dana Scully',
-    contact: 'dana@example.com',
+    contact: '11999990004',
+    cpf: '22233344455',
     dateOfBirth: '1974-02-23',
     sessionNotes: initialSessionNotesP3,
-  },
+  }),
 ];
-
-// --- Funções de criptografia mock ---
-const encryptMock = (data: string): string =>
-  data ? data.split('').reverse().join('') + '_encrypted' : '';
-
-const decryptMock = (data: string): string =>
-  data.endsWith('_encrypted') ? data.slice(0, -10).split('').reverse().join('') : data;
 
 // 🔓 Retorna lista descriptografada
 export const getMockPatientsList = (): Patient[] =>
-  mockPatients.map((patient) => ({
-    ...patient,
-    name: decryptMock(patient.name),
-    contact: decryptMock(patient.contact),
-    dateOfBirth: decryptMock(patient.dateOfBirth),
-  }));
+  mockPatients.map(decryptPatient);
 
 // 🔒 Atualiza um paciente mock
 export const updateMockPatient = (updatedPatient: Patient): Patient => {
@@ -132,12 +125,7 @@ export const updateMockPatient = (updatedPatient: Patient): Patient => {
     return updatedPatient;
   }
 
-  const encryptedPatient: Patient = {
-    ...updatedPatient,
-    name: encryptMock(updatedPatient.name),
-    contact: encryptMock(updatedPatient.contact),
-    dateOfBirth: encryptMock(updatedPatient.dateOfBirth),
-  };
+  const encryptedPatient = encryptPatient(updatedPatient);
 
   mockPatients[index] = encryptedPatient;
   return updatedPatient;
@@ -147,12 +135,7 @@ export const updateMockPatient = (updatedPatient: Patient): Patient => {
 export const getMockPatientById = (id: string): Patient | null => {
   const patient = mockPatients.find((p) => p.id === id);
   if (!patient) return null;
-  return {
-    ...patient,
-    name: decryptMock(patient.name),
-    contact: decryptMock(patient.contact),
-    dateOfBirth: decryptMock(patient.dateOfBirth),
-  };
+  return decryptPatient(patient);
 };
 
 // 📆 Agendamentos mock

--- a/src/lib/patientCrypto.ts
+++ b/src/lib/patientCrypto.ts
@@ -1,0 +1,32 @@
+import type { Patient, SessionNote } from './types';
+import { encrypt, decrypt } from './utils';
+
+function encNote(note: SessionNote): SessionNote {
+  return { ...note, notes: encrypt(note.notes) };
+}
+
+function decNote(note: SessionNote): SessionNote {
+  return { ...note, notes: decrypt(note.notes) };
+}
+
+export function encryptPatient(patient: Patient): Patient {
+  return {
+    ...patient,
+    name: encrypt(patient.name),
+    contact: encrypt(patient.contact),
+    cpf: patient.cpf ? encrypt(patient.cpf) : undefined,
+    dateOfBirth: encrypt(patient.dateOfBirth),
+    sessionNotes: patient.sessionNotes.map(encNote),
+  };
+}
+
+export function decryptPatient(patient: Patient): Patient {
+  return {
+    ...patient,
+    name: decrypt(patient.name),
+    contact: decrypt(patient.contact),
+    cpf: patient.cpf ? decrypt(patient.cpf) : undefined,
+    dateOfBirth: decrypt(patient.dateOfBirth),
+    sessionNotes: patient.sessionNotes.map(decNote),
+  };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -26,6 +26,7 @@ export interface Patient {
   id: string;
   name: string;
   contact: string;
+  cpf?: string;
   dateOfBirth: string; // ISO 8601
   sessionNotes: SessionNote[];
 }

--- a/tests/patientCrypto.test.ts
+++ b/tests/patientCrypto.test.ts
@@ -1,0 +1,20 @@
+import { encryptPatient, decryptPatient } from '../src/lib/patientCrypto';
+import { Patient } from '../src/lib/types';
+
+const patient: Patient = {
+  id: 'p1',
+  name: 'Test',
+  contact: '1234567890',
+  cpf: '11122233344',
+  dateOfBirth: '2000-01-01',
+  sessionNotes: [
+    { id: 'n1', date: '2024-01-01', notes: 'ok' }
+  ],
+};
+
+test('encryptPatient/decryptPatient roundtrip', () => {
+  const enc = encryptPatient(patient);
+  expect(enc.name).not.toBe(patient.name);
+  const dec = decryptPatient(enc);
+  expect(dec).toEqual(patient);
+});

--- a/tests/timeline.test.ts
+++ b/tests/timeline.test.ts
@@ -1,9 +1,12 @@
 import { generateTimelineEvents } from '../src/lib/timeline';
-import { mockAppointments, mockPatients } from '../src/lib/mock-data';
+import { mockAppointments, getMockPatientsList } from '../src/lib/mock-data';
 
 test('generateTimelineEvents merges and sorts events', () => {
   const events = generateTimelineEvents();
-  expect(events.length).toBe(mockAppointments.length + mockPatients.reduce((sum, p) => sum + p.sessionNotes.length, 0));
+  const patients = getMockPatientsList();
+  expect(events.length).toBe(
+    mockAppointments.length + patients.reduce((sum, p) => sum + p.sessionNotes.length, 0)
+  );
   for (let i = 1; i < events.length; i++) {
     const prev = new Date(events[i - 1].date).getTime();
     const curr = new Date(events[i].date).getTime();


### PR DESCRIPTION
## Summary
- encrypt patient information with AES
- restrict patient views by role
- support CPF in patient forms and details
- update mock data to store encrypted patients
- document client-side encryption
- test patientCrypto utilities

## Testing
- `npx jest` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_6843825a6b308324ac8ff439dd483383