### PR TITLE
Implement role guard and AES patient encryption

### DIFF
--- a/src/app/(app)/patients/[id]/page.tsx
+++ b/src/app/(app)/patients/[id]/page.tsx
@@ -13,6 +13,7 @@ import { db } from '@/lib/firebaseClient';
 import { addDoc, collection, updateDoc, doc, deleteDoc, serverTimestamp } from 'firebase/firestore';
 import type { Task } from '@/lib/types';
 import { useToast } from '@/hooks/use-toast';
+import { useRequireRole } from '@/hooks/useRequireRole';
 
 interface PatientDetailPageProps {
   params: {
@@ -21,10 +22,27 @@ interface PatientDetailPageProps {
 }
 
 export default function PatientDetailPage({ params }: PatientDetailPageProps) {
+  const { isLoading, hasRole } = useRequireRole('Psicólogo');
   const { tasks } = useTasks(params.id);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [editing, setEditing] = useState<Task | null>(null);
   const { toast } = useToast();
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p>Carregando...</p>
+      </div>
+    );
+  }
+
+  if (!hasRole) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p>Acesso restrito.</p>
+      </div>
+    );
+  }
 
   const handleSave = async (data: Omit<Task, 'id' | 'createdAt' | 'updatedAt' | 'createdBy' | 'patientId'>) => {
     if (editing) {

--- a/src/app/(app)/patients/page.tsx
+++ b/src/app/(app)/patients/page.tsx
@@ -2,18 +2,36 @@
 
 import { useState, useEffect } from 'react';
 import type { Patient } from '@/lib/types';
-import { getMockPatientsList, updateMockPatient } from '@/lib/mock-data';
+import { getMockPatientsList, saveMockPatient } from '@/lib/mock-data';
 import { PatientTable } from '@/components/patients/PatientTable';
 import { Button } from '@/components/ui/button';
 import { PlusCircle } from 'lucide-react';
 import { PatientFormDialog } from '@/components/patients/PatientFormDialog';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useToast } from "@/hooks/use-toast";
+import { useRequireRole } from '@/hooks/useRequireRole';
 
 export default function PatientsPage() {
+  const { isLoading, hasRole } = useRequireRole('Psicólogo');
   const [patients, setPatients] = useState<Patient[]>([]);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const { toast } = useToast();
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p>Carregando...</p>
+      </div>
+    );
+  }
+
+  if (!hasRole) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p>Acesso restrito.</p>
+      </div>
+    );
+  }
 
   useEffect(() => {
     // Carrega lista de pacientes de exemplo
@@ -34,6 +52,8 @@ export default function PatientsPage() {
       }
     });
 
+    saveMockPatient(patientData);
+
     toast({
       title: patientData.id.startsWith("patient-") && patients.find(p => p.id === patientData.id)
         ? "Paciente Atualizado"
@@ -44,12 +64,6 @@ export default function PatientsPage() {
     setIsFormOpen(false);
   };
 
-  const handleUpdatePatient = (updatedPatient: Patient) => {
-    // Simula o salvamento com criptografia
-    updateMockPatient(updatedPatient);
-    // Atualiza a lista localmente buscando novamente os dados mock (agora com o paciente atualizado)
-    setPatients(getMockPatientsList());
-  };
 
   const handleDeletePatient = (patientId: string) => {
     setPatients(prevPatients => prevPatients.filter(p => p.id !== patientId));

--- a/src/components/patients/PatientDetailsClient.tsx
+++ b/src/components/patients/PatientDetailsClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { Patient, SessionNote } from "@/lib/types";
-import { getMockPatientById, updateMockPatient } from "@/lib/mock-data";
+import { getMockPatientById, saveMockPatient } from "@/lib/mock-data";
 import { useState, useEffect } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -56,7 +56,7 @@ export function PatientDetailsClient({ patientId }: PatientDetailsClientProps) {
         ...prev,
         sessionNotes: [...prev.sessionNotes, newNote],
       };
-      updateMockPatient(updated);
+      saveMockPatient(updated);
       return updated;
     });
 
@@ -75,7 +75,7 @@ export function PatientDetailsClient({ patientId }: PatientDetailsClientProps) {
         ...prev,
         sessionNotes: prev.sessionNotes.filter(note => note.id !== noteId),
       };
-      updateMockPatient(updated);
+      saveMockPatient(updated);
       return updated;
     });
 
@@ -102,7 +102,7 @@ const handleEditNote = async (
         note.id === noteId ? { ...note, notes: content, date } : note,
       ),
     };
-    updateMockPatient(updated);
+    saveMockPatient(updated);
     return updated;
   });
 
@@ -114,7 +114,7 @@ const handleEditNote = async (
 
 const handleSavePatient = (updatedPatient: Patient) => {
   setPatient(updatedPatient);
-  updateMockPatient(updatedPatient);
+  saveMockPatient(updatedPatient);
   toast({
     title: "Paciente Atualizado",
     description: "Os dados do paciente foram salvos com sucesso.",

--- a/src/hooks/useRequireRole.ts
+++ b/src/hooks/useRequireRole.ts
@@ -1,0 +1,18 @@
+"use client";
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/contexts/AuthContext';
+import type { UserRole } from '@/lib/types';
+
+export function useRequireRole(role: UserRole) {
+  const { user, isLoading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isLoading && (!user || user.role !== role)) {
+      router.replace('/');
+    }
+  }, [isLoading, user, role, router]);
+
+  return { user, isLoading, hasRole: !!user && user.role === role };
+}

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -1,5 +1,6 @@
 
 import { format, addDays } from 'date-fns';
+import { encrypt, tryDecrypt } from './utils';
 import type {
   Patient,
   Appointment,
@@ -108,39 +109,50 @@ export let mockPatients: Patient[] = [
   },
 ];
 
-// --- Funções de criptografia mock ---
-const encryptMock = (data: string): string =>
-  data ? data.split('').reverse().join('') + '_encrypted' : '';
-
-const decryptMock = (data: string): string =>
-  data.endsWith('_encrypted') ? data.slice(0, -10).split('').reverse().join('') : data;
+// --- Funções de criptografia ---
+const encryptField = (data: string): string => encrypt(data);
+const decryptField = (data: string): string => tryDecrypt(data);
 
 // 🔓 Retorna lista descriptografada
 export const getMockPatientsList = (): Patient[] =>
   mockPatients.map((patient) => ({
     ...patient,
-    name: decryptMock(patient.name),
-    contact: decryptMock(patient.contact),
-    dateOfBirth: decryptMock(patient.dateOfBirth),
+    name: decryptField(patient.name),
+    contact: decryptField(patient.contact),
+    dateOfBirth: decryptField(patient.dateOfBirth),
+    sessionNotes: patient.sessionNotes.map(n => ({
+      ...n,
+      notes: decryptField(n.notes),
+      patientHistorySummaryForAI: n.patientHistorySummaryForAI
+        ? decryptField(n.patientHistorySummaryForAI)
+        : undefined,
+    })),
   }));
 
 // 🔒 Atualiza um paciente mock
-export const updateMockPatient = (updatedPatient: Patient): Patient => {
-  const index = mockPatients.findIndex((p) => p.id === updatedPatient.id);
-  if (index === -1) {
-    console.error(`Paciente com ID ${updatedPatient.id} não encontrado.`);
-    return updatedPatient;
-  }
-
+export const saveMockPatient = (patient: Patient): Patient => {
+  const index = mockPatients.findIndex((p) => p.id === patient.id);
   const encryptedPatient: Patient = {
-    ...updatedPatient,
-    name: encryptMock(updatedPatient.name),
-    contact: encryptMock(updatedPatient.contact),
-    dateOfBirth: encryptMock(updatedPatient.dateOfBirth),
+    ...patient,
+    name: encryptField(patient.name),
+    contact: encryptField(patient.contact),
+    dateOfBirth: encryptField(patient.dateOfBirth),
+    sessionNotes: patient.sessionNotes.map(n => ({
+      ...n,
+      notes: encryptField(n.notes),
+      patientHistorySummaryForAI: n.patientHistorySummaryForAI
+        ? encryptField(n.patientHistorySummaryForAI)
+        : undefined,
+    })),
   };
 
-  mockPatients[index] = encryptedPatient;
-  return updatedPatient;
+  if (index === -1) {
+    mockPatients.push(encryptedPatient);
+  } else {
+    mockPatients[index] = encryptedPatient;
+  }
+
+  return patient;
 };
 
 // 🔍 Busca paciente pelo ID
@@ -149,9 +161,16 @@ export const getMockPatientById = (id: string): Patient | null => {
   if (!patient) return null;
   return {
     ...patient,
-    name: decryptMock(patient.name),
-    contact: decryptMock(patient.contact),
-    dateOfBirth: decryptMock(patient.dateOfBirth),
+    name: decryptField(patient.name),
+    contact: decryptField(patient.contact),
+    dateOfBirth: decryptField(patient.dateOfBirth),
+    sessionNotes: patient.sessionNotes.map(n => ({
+      ...n,
+      notes: decryptField(n.notes),
+      patientHistorySummaryForAI: n.patientHistorySummaryForAI
+        ? decryptField(n.patientHistorySummaryForAI)
+        : undefined,
+    })),
   };
 };
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,8 +9,8 @@ export function getCryptoKey(): Buffer {
   if (cachedKey) return cachedKey;
   const key = process.env.CRYPTO_SECRET_KEY;
   if (!key) {
-    if (process.env.NODE_ENV === "development") {
-      console.warn("[dev] Generated random CRYPTO_SECRET_KEY");
+    if (process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test") {
+      console.warn(`[${process.env.NODE_ENV}] Generated random CRYPTO_SECRET_KEY`);
       cachedKey = crypto.randomBytes(32);
       return cachedKey;
     }
@@ -42,4 +42,13 @@ export function encrypt(text: string): string {
 export function decrypt(ciphertext: string): string {
   const key = getCryptoKey().toString('base64');
   return CryptoJS.AES.decrypt(ciphertext, key).toString(CryptoJS.enc.Utf8);
+}
+
+export function tryDecrypt(value: string): string {
+  try {
+    const result = decrypt(value);
+    return result || value;
+  } catch {
+    return value;
+  }
 }

--- a/tests/timeline.test.ts
+++ b/tests/timeline.test.ts
@@ -1,5 +1,18 @@
-import { generateTimelineEvents } from '../src/lib/timeline';
-import { mockAppointments, mockPatients } from '../src/lib/mock-data';
+let generateTimelineEvents: typeof import('../src/lib/timeline').generateTimelineEvents;
+let mockAppointments: typeof import('../src/lib/mock-data').mockAppointments;
+let mockPatients: typeof import('../src/lib/mock-data').mockPatients;
+
+beforeAll(async () => {
+  process.env.CRYPTO_SECRET_KEY = Buffer.alloc(32).toString('base64');
+  ({ generateTimelineEvents } = await import('../src/lib/timeline'));
+  const data = await import('../src/lib/mock-data');
+  mockAppointments = data.mockAppointments;
+  mockPatients = data.mockPatients;
+});
+
+afterAll(() => {
+  delete process.env.CRYPTO_SECRET_KEY;
+});
 
 test('generateTimelineEvents merges and sorts events', () => {
   const events = generateTimelineEvents();


### PR DESCRIPTION
## Summary
- add `useRequireRole` hook
- add role checks to patient pages
- encrypt/decrypt patient data with AES
- support random crypto key in test env
- fix tests to set encryption key

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684382e7c51883248158e1812390cff7