### PR TITLE
Disable admin approval requirement

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -29,13 +29,8 @@ export default function AppLayout({
     );
   }
 
-  if (user && !user.isApproved) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <p>Aguardando aprovação do administrador...</p>
-      </div>
-    );
-  }
+  // A aprovação de administradores foi temporariamente desativada,
+  // portanto não bloqueamos o acesso de usuários não aprovados.
 
   return (
     <div className="flex min-h-screen w-full">

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -42,7 +42,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
             name: fbUser.displayName || '',
             email: fbUser.email || '',
             role: (data?.role as User['role']) || 'PSYCHOLOGIST',
-            isApproved: data?.isApproved ?? false,
+            // A aprovação automática está habilitada por padrão
+            isApproved: data?.isApproved ?? true,
             profileImage: fbUser.photoURL || undefined,
           };
           setUser(mappedUser);
@@ -104,7 +105,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       const ref = doc(db, 'users', fbUser.uid);
       const snap = await getDoc(ref);
       if (!snap.exists()) {
-        data = { role: 'PSYCHOLOGIST', isApproved: false };
+        // Novo usuário é aprovado automaticamente
+        data = { role: 'PSYCHOLOGIST', isApproved: true };
         await setDoc(ref, data);
       } else {
         data = snap.data() as Partial<User>;
@@ -114,7 +116,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         name: fbUser.displayName || '',
         email: fbUser.email || '',
         role: (data?.role as User['role']) || 'PSYCHOLOGIST',
-        isApproved: data?.isApproved ?? false,
+        // A aprovação automática está habilitada por padrão
+        isApproved: data?.isApproved ?? true,
         profileImage: fbUser.photoURL || undefined,
       };
       setUser(mappedUser);


### PR DESCRIPTION
## Summary
- disable blocking check for unapproved users
- auto approve new sign-ins

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843857aff688324b941be88dbfa08e6