### PR TITLE
Fix stray quote in AppointmentFormDialog

### DIFF
--- a/src/components/appointments/AppointmentFormDialog.tsx
+++ b/src/components/appointments/AppointmentFormDialog.tsx
@@ -168,7 +168,7 @@ export function AppointmentFormDialog({
   async function onSubmit(values: AppointmentFormValues) {
     setIsLoading(true);
     await new Promise((resolve) => setTimeout(resolve, 1000));
-    const [hours, minutes] = values.time.split(":"").map(Number);
+    const [hours, minutes] = values.time.split(":").map(Number);
     const combinedDateTime = setMinutes(setHours(values.date, hours), minutes);
     const appointmentData: Appointment = {
       id: appointment?.id || `appt-${Date.now()}`,


### PR DESCRIPTION
## Summary
- fix syntax error in AppointmentFormDialog.tsx

## Testing
- `npm test -- -w=1` *(fails: CRYPTO_SECRET_KEY is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68438c96a1b08324ab896ebade3c277f