### PR TITLE
Implement role-based access and user approval checks

### DIFF
--- a/src/app/(app)/tools/audit-log/page.tsx
+++ b/src/app/(app)/tools/audit-log/page.tsx
@@ -2,6 +2,7 @@
 
 import { useAuditLogs } from '@/hooks/useAuditLogs';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { RoleGate } from '@/components/auth/RoleGate';
 import {
   Table,
   TableBody,
@@ -15,16 +16,17 @@ export default function AuditLogPage() {
   const { logs } = useAuditLogs();
 
   return (
-    <div className="space-y-6">
-      <h1 className="text-3xl font-bold font-headline">Audit Trail</h1>
-      <Card className="shadow-lg rounded-lg">
-        <CardHeader>
-          <CardTitle>Logs Registrados</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <Table>
-            <TableHeader>
-              <TableRow>
+    <RoleGate allowed={["ADMIN"]}>
+      <div className="space-y-6">
+        <h1 className="text-3xl font-bold font-headline">Audit Trail</h1>
+        <Card className="shadow-lg rounded-lg">
+          <CardHeader>
+            <CardTitle>Logs Registrados</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
                 <TableHead>Ação</TableHead>
                 <TableHead>Usuário</TableHead>
                 <TableHead>Quando</TableHead>
@@ -51,5 +53,6 @@ export default function AuditLogPage() {
         </CardContent>
       </Card>
     </div>
+    </RoleGate>
   );
 }

--- a/src/app/(app)/user-approvals/page.tsx
+++ b/src/app/(app)/user-approvals/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useAuth } from "@/contexts/AuthContext";
+import { RoleGate } from "@/components/auth/RoleGate";
 import { db } from "@/lib/firebaseClient";
 import { collection, onSnapshot, query, where, updateDoc, doc } from "firebase/firestore";
 import { User } from "@/lib/types";
@@ -10,7 +10,6 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { useToast } from "@/hooks/use-toast";
 
 export default function UserApprovalsPage() {
-  const { user } = useAuth();
   const [pending, setPending] = useState<User[]>([]);
   const { toast } = useToast();
 
@@ -28,22 +27,20 @@ export default function UserApprovalsPage() {
     toast({ title: "Usuário aprovado" });
   };
 
-  if (!user || user.role !== "ADMIN") {
-    return <p className="p-8">Sem acesso.</p>;
-  }
-
   return (
-    <div className="space-y-6">
-      <h1 className="text-3xl font-bold font-headline">Aprovar Usuários</h1>
-      <Card className="shadow-lg rounded-lg">
-        <CardHeader>
-          <CardTitle>Pendentes</CardTitle>
-          <CardDescription>{pending.length} usuário(s) aguardando aprovação.</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <UserApprovalTable users={pending} onApprove={handleApprove} />
-        </CardContent>
-      </Card>
-    </div>
+    <RoleGate allowed={["ADMIN"]}>
+      <div className="space-y-6">
+        <h1 className="text-3xl font-bold font-headline">Aprovar Usuários</h1>
+        <Card className="shadow-lg rounded-lg">
+          <CardHeader>
+            <CardTitle>Pendentes</CardTitle>
+            <CardDescription>{pending.length} usuário(s) aguardando aprovação.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <UserApprovalTable users={pending} onApprove={handleApprove} />
+          </CardContent>
+        </Card>
+      </div>
+    </RoleGate>
   );
 }

--- a/src/app/pending-approval/page.tsx
+++ b/src/app/pending-approval/page.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useRouter } from "next/navigation";
+
+export default function PendingApprovalPage() {
+  const router = useRouter();
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center p-8 text-center">
+      <h1 className="text-2xl font-headline font-bold mb-4">Aguardando Aprovação</h1>
+      <p className="mb-6 max-w-md">
+        Seu cadastro foi recebido e aguarda aprovação de um administrador.
+        Você receberá acesso assim que for aprovado.
+      </p>
+      <Button onClick={() => router.push('/login')}>Voltar ao Login</Button>
+    </div>
+  );
+}

--- a/src/components/auth/RoleGate.tsx
+++ b/src/components/auth/RoleGate.tsx
@@ -1,0 +1,22 @@
+import { useAuth } from '@/contexts/AuthContext';
+import type { UserRole } from '@/lib/types';
+import React from 'react';
+
+interface RoleGateProps {
+  allowed: UserRole[];
+  children: React.ReactNode;
+}
+
+export function RoleGate({ allowed, children }: RoleGateProps) {
+  const { user, isLoading } = useAuth();
+
+  if (isLoading) {
+    return <div className="p-8">Carregando...</div>;
+  }
+
+  if (!user || !allowed.includes(user.role)) {
+    return <p className="p-8">Sem acesso.</p>;
+  }
+
+  return <>{children}</>;
+}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -12,6 +12,7 @@ import {
   GoogleAuthProvider,
   signInWithPopup,
   onAuthStateChanged,
+  signOut,
 } from 'firebase/auth';
 
 interface AuthContextType {
@@ -42,10 +43,19 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
             name: fbUser.displayName || '',
             email: fbUser.email || '',
             role: (data?.role as User['role']) || 'PSYCHOLOGIST',
-            // A aprovação automática está habilitada por padrão
             isApproved: data?.isApproved ?? true,
             profileImage: fbUser.photoURL || undefined,
           };
+
+          if (!mappedUser.isApproved) {
+            alert('Seu acesso ainda n\u00e3o foi aprovado.');
+            await signOut(auth);
+            setUser(null);
+            localStorage.removeItem('psiguard_user');
+            router.push('/pending-approval');
+            return;
+          }
+
           setUser(mappedUser);
           localStorage.setItem('psiguard_user', JSON.stringify(mappedUser));
         } catch (err) {
@@ -72,19 +82,28 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     // In a real app, you'd validate credentials against a backend.
     // For this mock, we'll use a hardcoded psychologist user if email matches.
     if (email === mockUser.email) {
-      setUser(mockUser);
-      localStorage.setItem('psiguard_user', JSON.stringify(mockUser));
       try {
-        await setDoc(doc(db, 'users', mockUser.id), {
+        const ref = doc(db, 'users', mockUser.id);
+        const snap = await getDoc(ref);
+        const data = snap.exists() ? (snap.data() as Partial<User>) : undefined;
+        if (data && data.isApproved === false) {
+          alert('Seu acesso ainda n\u00e3o foi aprovado.');
+          setIsLoading(false);
+          return;
+        }
+        await setDoc(ref, {
           role: mockUser.role,
-          isApproved: true,
+          isApproved: data?.isApproved ?? true,
           name: mockUser.name,
           email: mockUser.email,
         }, { merge: true });
+        const finalUser = { ...mockUser, isApproved: data?.isApproved ?? true };
+        setUser(finalUser);
+        localStorage.setItem('psiguard_user', JSON.stringify(finalUser));
+        router.push('/dashboard');
       } catch (err) {
         console.error('Failed to save mock user', err);
       }
-      router.push('/dashboard');
     } else {
       // Basic error handling - in a real app, show a toast or error message
       console.error("Login failed: Invalid credentials");
@@ -116,10 +135,17 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         name: fbUser.displayName || '',
         email: fbUser.email || '',
         role: (data?.role as User['role']) || 'PSYCHOLOGIST',
-        // A aprovação automática está habilitada por padrão
         isApproved: data?.isApproved ?? true,
         profileImage: fbUser.photoURL || undefined,
       };
+
+      if (!mappedUser.isApproved) {
+        alert('Seu acesso ainda n\u00e3o foi aprovado.');
+        await signOut(auth);
+        setIsLoading(false);
+        return;
+      }
+
       setUser(mappedUser);
       localStorage.setItem('psiguard_user', JSON.stringify(mappedUser));
       router.push('/dashboard');


### PR DESCRIPTION
## Summary
- add `RoleGate` component for role-based access
- enforce `isApproved` check during authentication
- route non-approved users to a pending approval page
- restrict admin pages using RoleGate

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438cce57e08324af0e557844ac90ba