### PR TITLE
Implement appointment history and patient encryption helpers

### DIFF
--- a/src/app/(app)/appointments/page.tsx
+++ b/src/app/(app)/appointments/page.tsx
@@ -9,15 +9,17 @@ import { AppointmentFormDialog } from '@/components/appointments/AppointmentForm
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useToast } from '@/hooks/use-toast';
 import { db } from '@/lib/firebaseClient';
-import { addDoc, collection, updateDoc, doc, deleteDoc } from 'firebase/firestore';
+import { addDoc, collection, updateDoc, doc, deleteDoc, serverTimestamp } from 'firebase/firestore';
 import { useAppointments } from '@/hooks/useAppointments';
 import { mockPatients } from '@/lib/mock-data';
+import { useAuth } from '@/contexts/AuthContext';
 
 export default function AppointmentsPage() {
   const { appointments } = useAppointments();
   const [patients, setPatients] = useState<Patient[]>([]);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const { toast } = useToast();
+  const { user } = useAuth();
 
   useEffect(() => {
     setPatients(mockPatients);
@@ -33,6 +35,12 @@ export default function AppointmentsPage() {
         durationMinutes: appointmentData.durationMinutes,
         status: appointmentData.status,
         notes: appointmentData.notes || '',
+      });
+      await addDoc(collection(db, 'appointments', appointmentData.id, 'history'), {
+        before: exists,
+        after: appointmentData,
+        userId: user?.id || 'unknown',
+        timestamp: serverTimestamp(),
       });
       toast({ title: 'Agendamento Atualizado' });
     } else {

--- a/src/lib/patientCrypto.ts
+++ b/src/lib/patientCrypto.ts
@@ -30,3 +30,11 @@ export function decryptPatient(patient: Patient): Patient {
     sessionNotes: patient.sessionNotes.map(decNote),
   };
 }
+
+export function decryptPatientForRole(
+  patient: Patient,
+  role: import('./types').UserRole,
+): Patient {
+  if (role !== 'PSYCHOLOGIST') return patient;
+  return decryptPatient(patient);
+}

--- a/src/lib/patientFirestore.ts
+++ b/src/lib/patientFirestore.ts
@@ -1,0 +1,19 @@
+import { db } from './firebaseClient';
+import { doc, setDoc, getDoc } from 'firebase/firestore';
+import type { Patient, UserRole } from './types';
+import { encryptPatient, decryptPatient } from './patientCrypto';
+
+export async function savePatient(patient: Patient): Promise<void> {
+  const enc = encryptPatient(patient);
+  await setDoc(doc(db, 'patients', patient.id), enc, { merge: true });
+}
+
+export async function fetchPatient(
+  id: string,
+  role: UserRole,
+): Promise<Patient | null> {
+  const snap = await getDoc(doc(db, 'patients', id));
+  if (!snap.exists()) return null;
+  const data = snap.data() as Patient;
+  return role === 'PSYCHOLOGIST' ? decryptPatient(data) : data;
+}

--- a/tests/patientCrypto.test.ts
+++ b/tests/patientCrypto.test.ts
@@ -1,5 +1,14 @@
-import { encryptPatient, decryptPatient } from '../src/lib/patientCrypto';
+import { encryptPatient, decryptPatient, decryptPatientForRole } from '../src/lib/patientCrypto';
 import { Patient } from '../src/lib/types';
+
+beforeAll(() => {
+  const key = Buffer.alloc(32).toString('base64');
+  process.env.CRYPTO_SECRET_KEY = key;
+});
+
+afterAll(() => {
+  delete process.env.CRYPTO_SECRET_KEY;
+});
 
 const patient: Patient = {
   id: 'p1',
@@ -17,4 +26,12 @@ test('encryptPatient/decryptPatient roundtrip', () => {
   expect(enc.name).not.toBe(patient.name);
   const dec = decryptPatient(enc);
   expect(dec).toEqual(patient);
+});
+
+test('decryptPatientForRole only decrypts for PSYCHOLOGIST', () => {
+  const enc = encryptPatient(patient);
+  const asPsych = decryptPatientForRole(enc, 'PSYCHOLOGIST');
+  expect(asPsych).toEqual(patient);
+  const asOther = decryptPatientForRole(enc, 'RECEPCAO');
+  expect(asOther.name).not.toBe(patient.name);
 });

--- a/tests/timeline.test.ts
+++ b/tests/timeline.test.ts
@@ -1,3 +1,4 @@
+process.env.CRYPTO_SECRET_KEY = Buffer.alloc(32).toString('base64');
 import { generateTimelineEvents } from '../src/lib/timeline';
 import { mockAppointments, getMockPatientsList } from '../src/lib/mock-data';
 


### PR DESCRIPTION
## Summary
- track appointment changes in `/appointments/{id}/history`
- restrict decryption based on user role
- add helper to save/fetch encrypted patients in Firestore
- update unit tests

## Testing
- `npx jest --runInBand --colors=false`

------
https://chatgpt.com/codex/tasks/task_e_68438d021d7c832496c6706f2664b27e