### PR TITLE
Fix split string syntax

### DIFF
--- a/src/components/appointments/AppointmentFormDialog.tsx
+++ b/src/components/appointments/AppointmentFormDialog.tsx
@@ -168,7 +168,7 @@ export function AppointmentFormDialog({
   async function onSubmit(values: AppointmentFormValues) {
     setIsLoading(true);
     await new Promise((resolve) => setTimeout(resolve, 1000));
-    const [hours, minutes] = values.time.split(":"").map(Number);
+    const [hours, minutes] = values.time.split(":").map(Number);
     const combinedDateTime = setMinutes(setHours(values.date, hours), minutes);
     const appointmentData: Appointment = {
       id: appointment?.id || `appt-${Date.now()}`,


### PR DESCRIPTION
## Summary
- fix time splitting syntax in AppointmentFormDialog

## Testing
- `npm run typecheck` *(fails: Cannot find module)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438fd91a408324a0e46d8f921d6dd8