### PR TITLE
Tarefa 10a e 10b

### DIFF
--- a/src/app/(app)/appointments/page.tsx
+++ b/src/app/(app)/appointments/page.tsx
@@ -8,6 +8,7 @@ import { PlusCircle } from 'lucide-react';
 import { AppointmentFormDialog } from '@/components/appointments/AppointmentFormDialog';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useToast } from '@/hooks/use-toast';
+import { useNotifications } from '@/contexts/NotificationContext';
 import { db } from '@/lib/firebaseClient';
 import { addDoc, collection, updateDoc, doc, deleteDoc, serverTimestamp } from 'firebase/firestore';
 import { useAppointments } from '@/hooks/useAppointments';
@@ -20,6 +21,7 @@ export default function AppointmentsPage() {
   const [isFormOpen, setIsFormOpen] = useState(false);
   const { toast } = useToast();
   const { user } = useAuth();
+  const { addNotification } = useNotifications();
 
   useEffect(() => {
     setPatients(mockPatients);
@@ -43,6 +45,7 @@ export default function AppointmentsPage() {
         timestamp: serverTimestamp(),
       });
       toast({ title: 'Agendamento Atualizado' });
+      addNotification(`Agendamento de ${appointmentData.patientName} atualizado`);
     } else {
       const { id, ...data } = appointmentData;
       await addDoc(collection(db, 'appointments'), data);

--- a/src/app/(app)/patients/page.tsx
+++ b/src/app/(app)/patients/page.tsx
@@ -10,12 +10,14 @@ import { PatientFormDialog } from '@/components/patients/PatientFormDialog';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/contexts/AuthContext";
+import { useNotifications } from "@/contexts/NotificationContext";
 
 export default function PatientsPage() {
   const { user } = useAuth();
   const [patients, setPatients] = useState<Patient[]>([]);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const { toast } = useToast();
+  const { addNotification } = useNotifications();
 
   if (!user || user.role !== 'Psicólogo') {
     return <p className="p-4">Acesso restrito aos psicólogos.</p>;
@@ -46,6 +48,10 @@ export default function PatientsPage() {
         : "Paciente Adicionado",
       description: `Os dados de ${patientData.name} foram salvos.`,
     });
+
+    if (!patients.find(p => p.id === patientData.id)) {
+      addNotification(`Novo paciente adicionado: ${patientData.name}`);
+    }
 
     setIsFormOpen(false);
   };

--- a/src/components/patients/PatientDetailsClient.tsx
+++ b/src/components/patients/PatientDetailsClient.tsx
@@ -12,10 +12,14 @@ import { AIInsightsSection } from "./AIInsightsSection";
 import { PatientFormDialog } from "./PatientFormDialog";
 import { format, parseISO, differenceInYears } from "date-fns";
 import { useToast } from "@/hooks/use-toast";
+import { useNotifications } from "@/contexts/NotificationContext";
 import { usePatientAssessments } from "@/hooks/usePatientAssessments";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import Image from "next/image";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { AlertTriangle } from "lucide-react";
+import { useCriticalTerms } from "@/hooks/useCriticalTerms";
 
 interface PatientDetailsClientProps {
   patientId: string;
@@ -26,7 +30,9 @@ export function PatientDetailsClient({ patientId }: PatientDetailsClientProps) {
   const [patient, setPatient] = useState<Patient | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const { toast } = useToast();
+  const { addNotification } = useNotifications();
   const { data: assessments, loading: loadingAssessments } = usePatientAssessments(patientId);
+  const criticalTerms = useCriticalTerms(patient ? patient.sessionNotes : []);
 
   useEffect(() => {
     const foundPatient = getMockPatientById(patientId);
@@ -64,6 +70,7 @@ export function PatientDetailsClient({ patientId }: PatientDetailsClientProps) {
       title: "Nota Adicionada",
       description: "A nova nota de sessão foi salva com sucesso.",
     });
+    addNotification(`Nota adicionada para ${patient.name}`);
   };
 
   const handleDeleteNote = async (noteId: string) => {
@@ -142,6 +149,17 @@ const handleSavePatient = (updatedPatient: Patient) => {
 
   return (
     <div className="space-y-6">
+      {criticalTerms.length > 0 && (
+        <Alert variant="destructive" className="flex items-start gap-2">
+          <AlertTriangle className="h-5 w-5 mt-0.5" />
+          <div>
+            <AlertTitle>Atenção</AlertTitle>
+            <AlertDescription>
+              Termos críticos detectados nas notas: {criticalTerms.join(', ')}.
+            </AlertDescription>
+          </div>
+        </Alert>
+      )}
       <div className="flex items-center justify-between mb-6">
         <Button asChild variant="outline" className="shadow-sm">
           <Link href="/patients">

--- a/src/contexts/NotificationContext.tsx
+++ b/src/contexts/NotificationContext.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import { createContext, useContext, useState, ReactNode } from 'react';
+import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { collection, onSnapshot, addDoc, doc, updateDoc, orderBy, query, serverTimestamp } from 'firebase/firestore';
+import { db } from '@/lib/firebaseClient';
+import { useAuth } from './AuthContext';
 
 export interface Notification {
   id: string;
@@ -11,34 +14,56 @@ export interface Notification {
 interface NotificationContextType {
   notifications: Notification[];
   unreadCount: number;
-  markAsRead: (id: string) => void;
-  markAllAsRead: () => void;
+  markAsRead: (id: string) => Promise<void>;
+  markAllAsRead: () => Promise<void>;
+  addNotification: (message: string) => Promise<void>;
 }
 
 const NotificationContext = createContext<NotificationContextType | undefined>(undefined);
 
-const defaultNotifications: Notification[] = [
-  { id: '1', message: 'Novo paciente adicionado \u00e0 lista de espera: Diana Prince', read: false },
-  { id: '2', message: 'Consulta amanh\u00e3 com Alice Wonderland \u00e0s 10:00', read: false },
-  { id: '3', message: 'Entre em contato com Clark Kent - aguardando h\u00e1 3 dias', read: false },
-  { id: '4', message: 'Revisar tarefas administrativas pendentes', read: false },
-];
+const defaultNotifications: Notification[] = [];
 
 export const NotificationProvider = ({ children }: { children: ReactNode }) => {
+  const { user } = useAuth();
   const [notifications, setNotifications] = useState<Notification[]>(defaultNotifications);
 
-  const markAsRead = (id: string) => {
-    setNotifications((prev) => prev.map((n) => (n.id === id ? { ...n, read: true } : n)));
+  useEffect(() => {
+    if (!user) return;
+    const q = query(collection(db, 'notifications', user.id, 'items'), orderBy('createdAt', 'desc'));
+    const unsub = onSnapshot(q, (snap) => {
+      const data = snap.docs.map((d) => ({ id: d.id, ...(d.data() as any) })) as Notification[];
+      setNotifications(data);
+    });
+    return () => unsub();
+  }, [user]);
+
+  const addNotification = async (message: string) => {
+    if (!user) return;
+    await addDoc(collection(db, 'notifications', user.id, 'items'), {
+      message,
+      read: false,
+      createdAt: serverTimestamp(),
+    });
   };
 
-  const markAllAsRead = () => {
-    setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+  const markAsRead = async (id: string) => {
+    if (!user) return;
+    await updateDoc(doc(db, 'notifications', user.id, 'items', id), { read: true });
+  };
+
+  const markAllAsRead = async () => {
+    if (!user) return;
+    await Promise.all(
+      notifications
+        .filter((n) => !n.read)
+        .map((n) => updateDoc(doc(db, 'notifications', user.id, 'items', n.id), { read: true }))
+    );
   };
 
   const unreadCount = notifications.filter((n) => !n.read).length;
 
   return (
-    <NotificationContext.Provider value={{ notifications, unreadCount, markAsRead, markAllAsRead }}>
+    <NotificationContext.Provider value={{ notifications, unreadCount, markAsRead, markAllAsRead, addNotification }}>
       {children}
     </NotificationContext.Provider>
   );

--- a/src/hooks/useCriticalTerms.ts
+++ b/src/hooks/useCriticalTerms.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react';
+import type { SessionNote } from '@/lib/types';
+
+const TERMS = ['ideação suicida', 'automutilação', 'abandono escolar'];
+
+export function useCriticalTerms(notes: SessionNote[]): string[] {
+  return useMemo(() => {
+    const found = new Set<string>();
+    notes.forEach((n) => {
+      const lower = n.notes.toLowerCase();
+      TERMS.forEach((t) => {
+        if (lower.includes(t)) found.add(t);
+      });
+    });
+    return Array.from(found);
+  }, [notes]);
+}


### PR DESCRIPTION
## Summary
- add hook `useCriticalTerms` to detect critical terms
- show alert with detected terms on patient record page
- persist internal notifications in Firestore
- log new patient and appointment updates to notifications
- toast when adding session notes triggers a notification

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684391de19d8832481181b41a640a3b1