### PR TITLE
Implement waitlist drag scheduling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,8 @@
         "patch-package": "^8.0.0",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
+        "react-dnd": "^16.0.1",
+        "react-dnd-html5-backend": "^16.0.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.57.0",
         "recharts": "^2.15.1",
@@ -4806,6 +4808,24 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@react-dnd/asap": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-5.0.2.tgz",
+      "integrity": "sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/invariant": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-4.0.2.tgz",
+      "integrity": "sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/shallowequal": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz",
+      "integrity": "sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==",
+      "license": "MIT"
+    },
     "node_modules/@sendgrid/client": {
       "version": "8.1.5",
       "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-8.1.5.tgz",
@@ -6923,6 +6943,17 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
     },
+    "node_modules/dnd-core": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-16.0.1.tgz",
+      "integrity": "sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/asap": "^5.0.1",
+        "@react-dnd/invariant": "^4.0.1",
+        "redux": "^4.2.0"
+      }
+    },
     "node_modules/doc-path": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/doc-path/-/doc-path-4.1.1.tgz",
@@ -8578,6 +8609,21 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/html-entities": {
       "version": "2.6.0",
@@ -11671,6 +11717,45 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-dnd": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-16.0.1.tgz",
+      "integrity": "sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/invariant": "^4.0.1",
+        "@react-dnd/shallowequal": "^4.0.1",
+        "dnd-core": "^16.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "@types/hoist-non-react-statics": ">= 3.3.1",
+        "@types/node": ">= 12",
+        "@types/react": ">= 16",
+        "react": ">= 16.14"
+      },
+      "peerDependenciesMeta": {
+        "@types/hoist-non-react-statics": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-dnd-html5-backend": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz",
+      "integrity": "sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==",
+      "license": "MIT",
+      "dependencies": {
+        "dnd-core": "^16.0.1"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -11872,6 +11957,15 @@
       "license": "MIT",
       "dependencies": {
         "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "patch-package": "^8.0.0",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.57.0",
     "recharts": "^2.15.1",

--- a/src/app/(app)/appointments/page.tsx
+++ b/src/app/(app)/appointments/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from 'react';
-import type { Appointment, Patient } from '@/lib/types';
+import type { Appointment, Patient, WaitingListItem } from '@/lib/types';
 import { AppointmentCalendarView } from '@/components/appointments/AppointmentCalendarView';
 import { Button } from '@/components/ui/button';
 import { PlusCircle } from 'lucide-react';
@@ -11,13 +11,18 @@ import { useToast } from '@/hooks/use-toast';
 import { db } from '@/lib/firebaseClient';
 import { addDoc, collection, updateDoc, doc, deleteDoc, serverTimestamp } from 'firebase/firestore';
 import { useAppointments } from '@/hooks/useAppointments';
-import { mockPatients } from '@/lib/mock-data';
+import { mockPatients, mockWaitingList } from '@/lib/mock-data';
 import { useAuth } from '@/contexts/AuthContext';
+import { WaitlistDragList } from '@/components/waitlist/WaitlistDragList';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+import { WeeklySchedule } from '@/components/appointments/WeeklySchedule';
 
 export default function AppointmentsPage() {
   const { appointments } = useAppointments();
   const [patients, setPatients] = useState<Patient[]>([]);
   const [isFormOpen, setIsFormOpen] = useState(false);
+  const [waitingList, setWaitingList] = useState(mockWaitingList);
   const { toast } = useToast();
   const { user } = useAuth();
 
@@ -56,6 +61,73 @@ export default function AppointmentsPage() {
     toast({ title: 'Agendamento Cancelado', variant: 'destructive' });
   };
 
+  const handleDropFromWaitlist = (date: Date, item: WaitingListItem) => {
+    const iso = date.toISOString();
+    if (appointments.some(a => a.dateTime === iso)) {
+      toast({
+        title: 'Horário Ocupado',
+        variant: 'destructive',
+      });
+      return;
+    }
+    const newAppt: Appointment = {
+      id: `appt-${Date.now()}`,
+      patientId: item.id,
+      patientName: item.patientName,
+      contact: item.contact,
+      dateTime: iso,
+      durationMinutes: 50,
+      status: 'pending',
+      notes: item.notes,
+    };
+    handleAddOrUpdateAppointment(newAppt);
+    setWaitingList(prev => prev.filter(w => w.id !== item.id));
+  };
+
+  if (user?.role === 'AGENDAMENTO') {
+    return (
+      <DndProvider backend={HTML5Backend}>
+        <div className="flex flex-col gap-4 md:flex-row">
+          <div className="flex-1 space-y-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <h1 className="text-3xl font-bold font-headline">Agendamentos</h1>
+              </div>
+              <AppointmentFormDialog
+                isOpen={isFormOpen}
+                onOpenChange={setIsFormOpen}
+                onSave={handleAddOrUpdateAppointment}
+                patients={patients}
+                appointments={appointments}
+                appointment={null}
+              >
+                <Button onClick={() => setIsFormOpen(true)} className="shadow-md">
+                  <PlusCircle className="mr-2 h-5 w-5" />
+                  Novo
+                </Button>
+              </AppointmentFormDialog>
+            </div>
+            <Card className="shadow-lg rounded-lg">
+              <CardHeader>
+                <CardTitle>Agenda Semanal</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <WeeklySchedule
+                  appointments={appointments}
+                  onDropFromWaitlist={handleDropFromWaitlist}
+                />
+              </CardContent>
+            </Card>
+          </div>
+          <div className="w-full md:w-64">
+            <h2 className="text-lg font-bold mb-2">Lista de Espera</h2>
+            <WaitlistDragList items={waitingList} />
+          </div>
+        </div>
+      </DndProvider>
+    );
+  }
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -70,6 +142,7 @@ export default function AppointmentsPage() {
           onOpenChange={setIsFormOpen}
           onSave={handleAddOrUpdateAppointment}
           patients={patients}
+          appointments={appointments}
           appointment={null}
         >
           <Button onClick={() => setIsFormOpen(true)} className="shadow-md">

--- a/src/components/appointments/AppointmentCalendarView.tsx
+++ b/src/components/appointments/AppointmentCalendarView.tsx
@@ -251,6 +251,7 @@ export function AppointmentCalendarView({
       <AppointmentFormDialog
         appointment={editingAppointment}
         patients={patients}
+        appointments={appointments}
         onSave={(data) => {
           setEditingAppointment(null);
           onUpdateAppointment(data);

--- a/src/components/appointments/AppointmentFormDialog.tsx
+++ b/src/components/appointments/AppointmentFormDialog.tsx
@@ -38,6 +38,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { CalendarIcon, Loader2, Clock } from "lucide-react";
 import { cn, formatCPF, isValidCPF } from "@/lib/utils";
+import { useToast } from "@/hooks/use-toast";
 import { format, parseISO, setHours, setMinutes, addMinutes, isValid } from "date-fns";
 import type { Appointment, Patient, AttendanceStatus } from "@/lib/types";
 import { mockAppointments } from "@/lib/mock-data";
@@ -71,6 +72,7 @@ interface AppointmentFormDialogProps {
   defaultDate?: Date;
   isOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
+  appointments?: Appointment[];
 }
 
 export function AppointmentFormDialog({
@@ -81,12 +83,14 @@ export function AppointmentFormDialog({
   defaultDate,
   isOpen: controlledIsOpen,
   onOpenChange: controlledOnOpenChange,
+  appointments,
 }: AppointmentFormDialogProps) {
   const [internalOpen, setInternalOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [patientQuery, setPatientQuery] = useState('');
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [phoneError, setPhoneError] = useState<string | null>(null);
+  const { toast } = useToast();
 
   const isOpen =
     controlledIsOpen !== undefined ? controlledIsOpen : internalOpen;
@@ -186,11 +190,25 @@ export function AppointmentFormDialog({
     await new Promise((resolve) => setTimeout(resolve, 1000));
     const [hours, minutes] = values.time.split(":").map(Number);
     const combinedDateTime = setMinutes(setHours(values.date, hours), minutes);
+    const iso = combinedDateTime.toISOString();
+    if (
+      appointments?.some(
+        (a) => a.id !== appointment?.id && a.dateTime === iso
+      )
+    ) {
+      toast({
+        title: "Horário Ocupado",
+        description: "Já existe um agendamento neste horário.",
+        variant: "destructive",
+      });
+      setIsLoading(false);
+      return;
+    }
     const appointmentData: Appointment = {
       id: appointment?.id || `appt-${Date.now()}`,
       patientId: values.patientId,
       patientName: patients.find((p) => p.id === values.patientId)?.name ?? "",
-      dateTime: combinedDateTime.toISOString(),
+      dateTime: iso,
       durationMinutes: values.durationMinutes,
       status: values.status as AttendanceStatus,
       notes: values.notes,

--- a/src/components/appointments/WeeklySchedule.tsx
+++ b/src/components/appointments/WeeklySchedule.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useDrop } from 'react-dnd';
+import type { Appointment, WaitingListItem } from '@/lib/types';
+import { format, startOfWeek, addDays, setHours, setMinutes } from 'date-fns';
+import { cn } from '@/lib/utils';
+import React from 'react';
+import { WAITING_ITEM_TYPE } from '@/components/waitlist/WaitlistDragList';
+
+interface WeeklyScheduleProps {
+  appointments: Appointment[];
+  onDropFromWaitlist: (date: Date, item: WaitingListItem) => void;
+}
+
+export function WeeklySchedule({ appointments, onDropFromWaitlist }: WeeklyScheduleProps) {
+  const weekStart = startOfWeek(new Date(), { weekStartsOn: 1 });
+  const days = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
+  const times = Array.from({ length: 20 }, (_, i) => {
+    const hour = 8 + Math.floor(i / 2);
+    const minute = (i % 2) * 30;
+    return { hour, minute };
+  });
+
+  const getAppt = (date: Date) =>
+    appointments.find(a => new Date(a.dateTime).getTime() === date.getTime());
+
+  const renderCell = (day: Date, time: { hour: number; minute: number }) => {
+    const start = setMinutes(setHours(day, time.hour), time.minute);
+    const appt = getAppt(start);
+    const [{ isOver, canDrop }, drop] = useDrop<WaitingListItem, void, { isOver: boolean; canDrop: boolean }>({
+      accept: WAITING_ITEM_TYPE,
+      drop: item => onDropFromWaitlist(start, item),
+      canDrop: () => !appt,
+      collect: monitor => ({
+        isOver: monitor.isOver(),
+        canDrop: monitor.canDrop(),
+      }),
+    });
+
+    return (
+      <div
+        key={`${day.toDateString()}-${time.hour}-${time.minute}`}
+        ref={drop as unknown as React.Ref<HTMLDivElement>}
+        className={cn(
+          'h-12 border flex items-center justify-center text-xs',
+          appt && 'bg-primary/10',
+          isOver && canDrop && !appt && 'bg-green-200',
+          isOver && !canDrop && 'bg-red-200'
+        )}
+      >
+        {appt ? appt.patientName : format(start, 'HH:mm')}
+      </div>
+    );
+  };
+
+  return (
+    <div className="overflow-x-auto">
+      <div className="grid text-center" style={{ gridTemplateColumns: `60px repeat(7, 1fr)` }}>
+        <div className="border" />
+        {days.map(d => (
+          <div key={`head-${d.toDateString()}`} className="border px-1 py-1 text-xs font-medium">
+            {format(d, 'EEE dd/MM')}
+          </div>
+        ))}
+        {times.map((t, idx) => (
+          <React.Fragment key={idx}>
+            <div className="border flex items-center justify-center text-xs font-medium">
+              {format(setMinutes(setHours(weekStart, t.hour), t.minute), 'HH:mm')}
+            </div>
+            {days.map(day => renderCell(day, t))}
+          </React.Fragment>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/waitlist/WaitlistDragList.tsx
+++ b/src/components/waitlist/WaitlistDragList.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useDrag } from 'react-dnd';
+import React from 'react';
+import type { WaitingListItem } from '@/lib/types';
+import { cn } from '@/lib/utils';
+
+export const WAITING_ITEM_TYPE = "WAITING_ITEM";
+
+interface WaitlistDragListProps {
+  items: WaitingListItem[];
+}
+
+export function WaitlistDragList({ items }: WaitlistDragListProps) {
+  return (
+    <div className="space-y-2">
+      {items.length === 0 && (
+        <p className="text-sm text-muted-foreground">Lista vazia.</p>
+      )}
+      {items.map((item) => (
+        <DraggableItem key={item.id} item={item} />
+      ))}
+    </div>
+  );
+}
+
+function DraggableItem({ item }: { item: WaitingListItem }) {
+  const [{ isDragging }, drag] = useDrag(() => ({
+    type: WAITING_ITEM_TYPE,
+    item,
+    collect: (monitor) => ({ isDragging: monitor.isDragging() }),
+  }), [item]);
+
+  return (
+    <div
+      ref={drag as unknown as React.Ref<HTMLDivElement>}
+      className={cn(
+        "cursor-grab rounded border bg-card p-2 shadow-sm",
+        isDragging && "opacity-50"
+      )}
+    >
+      <p className="font-medium leading-none">{item.patientName}</p>
+      <p className="text-sm text-muted-foreground">{item.contact}</p>
+      {item.notes && (
+        <p className="text-xs text-muted-foreground truncate">{item.notes}</p>
+      )}
+    </div>
+  );
+}

--- a/src/lib/firebaseAdmin.ts
+++ b/src/lib/firebaseAdmin.ts
@@ -14,15 +14,15 @@ if (!getApps().length) {
 export const adminDb = getFirestore(app);
 export const adminAuth = getAuth(app);
 
-const TOKEN_SECRET = process.env.ASSESSMENT_TOKEN_SECRET;
+const TOKEN_SECRET = process.env.ASSESSMENT_TOKEN_SECRET as string | undefined;
 if (!TOKEN_SECRET) {
   throw new Error('ASSESSMENT_TOKEN_SECRET environment variable is required');
 }
 
 export function signAssessmentToken(payload: { assessmentId: string; patientId: string }): string {
-  return jwt.sign(payload, TOKEN_SECRET, { expiresIn: '7d' });
+  return jwt.sign(payload, TOKEN_SECRET as string, { expiresIn: '7d' });
 }
 
 export function verifyAssessmentToken(token: string): { assessmentId: string; patientId: string } {
-  return jwt.verify(token, TOKEN_SECRET) as { assessmentId: string; patientId: string };
+  return jwt.verify(token, TOKEN_SECRET as string) as { assessmentId: string; patientId: string };
 }


### PR DESCRIPTION
## Summary
- add draggable waiting list items
- implement weekly schedule with drop targets
- validate overlapping appointments when scheduling
- show schedule with waitlist sidebar in AGENDAMENTO mode
- fix firebase admin token typing

## Testing
- `npm run typecheck` *(fails: TS errors in existing files)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843916933ec83248a15e489c0c054aa