### PR TITLE
Add navigation config and top tabs

### DIFF
--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -1,0 +1,20 @@
+# Navigation Configuration
+
+The main menu items are defined in `src/lib/navigation.ts`.
+Each entry has four fields:
+
+- `label`: short text shown in the UI.
+- `description`: up to 15 words describing the page.
+- `href`: route path used for navigation.
+- `category`: grouping name used by the sidebar and top tabs.
+
+Example:
+
+```ts
+export const navigation = [
+  { label: 'Dashboard', description: 'Visão geral rápida das métricas', href: '/dashboard', category: 'Consultório' }
+]
+```
+
+Components such as `Sidebar` and `TopTabs` import this array to build the UI.
+Keeping the list centralized ensures new routes appear across the app.

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
 import Sidebar from '@/components/layout/Sidebar';
 import { AppHeader } from '@/components/layout/Header';
+import { TopTabs } from '@/components/layout/TopTabs';
 
 
 export default function AppLayout({
@@ -37,6 +38,7 @@ export default function AppLayout({
       <Sidebar />
       <div className="flex flex-1 flex-col">
         <AppHeader />
+        <TopTabs />
         <main className="flex-1 overflow-y-auto bg-background p-8 md:p-12">
           {children}
         </main>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -26,10 +26,11 @@ import {
   LogOut,
   ChevronDown,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import { motion } from "framer-motion";
 import { useSmartMenu } from "@/lib/use-smart-menu";
+import { navigation, NavItem } from "@/lib/navigation";
 
 function SidebarContent({
   className,
@@ -41,61 +42,45 @@ function SidebarContent({
   const pathname = usePathname();
   const { logout, user } = useAuth();
 
-  const sections = [
-    {
-      title: "Consultório",
-      items: [
-        { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
-        { href: "/patients", label: "Pacientes", icon: Users },
-        { href: "/appointments", label: "Agendamentos", icon: CalendarDays },
-        { href: "/waiting-list", label: "Lista de Espera", icon: ListChecks },
-      ],
+  const icons: Record<string, React.ComponentType<{ className?: string }>> = {
+    '/dashboard': LayoutDashboard,
+    '/patients': Users,
+    '/appointments': CalendarDays,
+    '/waiting-list': ListChecks,
+    '/templates': FileText,
+    '/medications': Pill,
+    '/self-care': HeartPulse,
+    '/knowledge-base': BookOpenCheck,
+    '/analytics': LineChart,
+    '/analytics/psychologist': LineChart,
+    '/settings': Settings,
+    '/user-approvals': Users,
+  };
+
+  const items = navigation.filter(
+    (item) => item.href !== '/user-approvals' || user?.role === 'ADMIN',
+  );
+
+  const sections = items.reduce(
+    (acc: Record<string, NavItem[]>, item) => {
+      acc[item.category] = acc[item.category] || [];
+      acc[item.category].push(item);
+      return acc;
     },
-    {
-      title: "Ferramentas",
-      items: [
-        { href: "/templates", label: "Modelos", icon: FileText },
-        { href: "/medications", label: "Guia Rápido", icon: Pill },
-        { href: "/self-care", label: "Saúde Mental", icon: HeartPulse },
-        {
-          href: "/knowledge-base",
-          label: "Base de Conhecimento",
-          icon: BookOpenCheck,
-        },
-        { href: "/analytics", label: "Tendências", icon: LineChart },
-        {
-          href: "/analytics/psychologist",
-          label: "Indicadores",
-          icon: LineChart,
-        },
-      ],
-    },
-    {
-      title: "Sistema",
-      items: [
-        { href: "/settings", label: "Configurações", icon: Settings },
-        ...(user?.role === "ADMIN"
-          ? [
-              {
-                href: "/user-approvals",
-                label: "Aprovar Usuários",
-                icon: Users,
-              },
-            ]
-          : []),
-      ],
-    },
-  ];
+    {},
+  );
+
+  const sectionEntries = Object.entries(sections).map(([title, items]) => ({
+    title,
+    items,
+  }));
 
   const [openSections, setOpenSections] = useState<Record<string, boolean>>(
     () =>
-      sections.reduce(
-        (acc, s) => {
-          acc[s.title] = true;
-          return acc;
-        },
-        {} as Record<string, boolean>,
-      ),
+      sectionEntries.reduce((acc, s) => {
+        acc[s.title] = true;
+        return acc;
+      }, {} as Record<string, boolean>),
   );
 
   const toggleSection = (title: string) =>
@@ -114,7 +99,7 @@ function SidebarContent({
         </Link>
       </div>
       <nav className="flex-1 overflow-y-auto px-2 space-y-6 text-sm">
-        {sections.map((section, i) => (
+        {sectionEntries.map((section, i) => (
           <div
             key={section.title}
             className={cn(
@@ -136,23 +121,26 @@ function SidebarContent({
             </button>
             {openSections[section.title] && (
               <ul className="space-y-1">
-                {section.items.map((item) => (
-                  <li key={item.href}>
-                    <Link
-                      href={item.href}
-                      onClick={() => {
-                        onNavigate?.();
-                      }}
-                      className={cn(
-                        "flex items-center gap-2 rounded-md px-4 py-2 hover:bg-primary/15 focus:outline focus:outline-2 focus:outline-primary/70",
-                        pathname === item.href && "bg-primary/15 font-semibold",
-                      )}
-                    >
-                      <item.icon className="h-[18px] w-[18px]" />
-                      <span>{item.label}</span>
-                    </Link>
-                  </li>
-                ))}
+                {section.items.map((item) => {
+                  const Icon = icons[item.href];
+                  return (
+                    <li key={item.href}>
+                      <Link
+                        href={item.href}
+                        onClick={() => {
+                          onNavigate?.();
+                        }}
+                        className={cn(
+                          "flex items-center gap-2 rounded-md px-4 py-2 hover:bg-primary/15 focus:outline focus:outline-2 focus:outline-primary/70",
+                          pathname === item.href && "bg-primary/15 font-semibold",
+                        )}
+                      >
+                        {Icon && <Icon className="h-[18px] w-[18px]" />}
+                        <span>{item.label}</span>
+                      </Link>
+                    </li>
+                  );
+                })}
               </ul>
             )}
           </div>

--- a/src/components/layout/TopTabs.tsx
+++ b/src/components/layout/TopTabs.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { usePathname, useRouter } from "next/navigation";
+import { navigation } from "@/lib/navigation";
+
+export function TopTabs() {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const active = navigation.find((n) =>
+    pathname === n.href || pathname.startsWith(n.href + "/")
+  );
+
+  const category = active?.category;
+  if (!category) return null;
+
+  const items = navigation.filter((n) => n.category === category);
+  const value = active?.href;
+
+  return (
+    <Tabs value={value} onValueChange={(href) => router.push(href)} className="px-4">
+      <TabsList>
+        {items.map((item) => (
+          <TabsTrigger key={item.href} value={item.href}>
+            {item.label}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+    </Tabs>
+  );
+}

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -1,0 +1,81 @@
+export type NavItem = {
+  label: string;
+  description: string;
+  href: string;
+  category: string;
+};
+
+export const navigation: NavItem[] = [
+  {
+    label: 'Dashboard',
+    description: 'Vis\u00e3o geral r\u00e1pida das m\u00e9tricas e atividades recentes.',
+    href: '/dashboard',
+    category: 'Consult\u00f3rio',
+  },
+  {
+    label: 'Pacientes',
+    description: 'Gerencie registros, dados e hist\u00f3rico de atendimentos.',
+    href: '/patients',
+    category: 'Consult\u00f3rio',
+  },
+  {
+    label: 'Agendamentos',
+    description: 'Controle e organize consultas na agenda.',
+    href: '/appointments',
+    category: 'Consult\u00f3rio',
+  },
+  {
+    label: 'Lista de Espera',
+    description: 'Acompanhe pacientes aguardando vagas dispon\u00edveis.',
+    href: '/waiting-list',
+    category: 'Consult\u00f3rio',
+  },
+  {
+    label: 'Modelos',
+    description: 'Modelos de documentos e prescri\u00e7\u00f5es para agilizar atendimento.',
+    href: '/templates',
+    category: 'Ferramentas',
+  },
+  {
+    label: 'Guia R\u00e1pido',
+    description: 'Refer\u00eancia r\u00e1pida de medicamentos e dosagens.',
+    href: '/medications',
+    category: 'Ferramentas',
+  },
+  {
+    label: 'Sa\u00fade Mental',
+    description: 'Ferramentas e dicas para autocuidado e bem-estar.',
+    href: '/self-care',
+    category: 'Ferramentas',
+  },
+  {
+    label: 'Base de Conhecimento',
+    description: 'Artigos e materiais de apoio para profissionais.',
+    href: '/knowledge-base',
+    category: 'Ferramentas',
+  },
+  {
+    label: 'Tend\u00eancias',
+    description: 'Gr\u00e1ficos e estat\u00edsticas de uso do sistema.',
+    href: '/analytics',
+    category: 'Ferramentas',
+  },
+  {
+    label: 'Indicadores',
+    description: 'M\u00e9tricas espec\u00edficas para avalia\u00e7\u00e3o de psic\u00f3logos.',
+    href: '/analytics/psychologist',
+    category: 'Ferramentas',
+  },
+  {
+    label: 'Configura\u00e7\u00f5es',
+    description: 'Personalize prefer\u00eancias e integra\u00e7\u00f5es do sistema.',
+    href: '/settings',
+    category: 'Sistema',
+  },
+  {
+    label: 'Aprovar Usu\u00e1rios',
+    description: 'Gerencie solicita\u00e7\u00f5es de acesso de novos profissionais.',
+    href: '/user-approvals',
+    category: 'Sistema',
+  },
+];


### PR DESCRIPTION
## Summary
- centralize sidebar links in `src/lib/navigation.ts`
- use navigation config when rendering the Sidebar
- add `TopTabs` component to show category tabs
- render `TopTabs` in the main layout
- document the navigation format for future contributors

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a919429c8324ad3b48ba532f6258