### PR TITLE
Apply modern fonts and colors

### DIFF
--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -13,10 +13,10 @@
 
 ## Style Guidelines:
 
-- Primary color: Dark petrol blue (#014F86) for a sophisticated feel.
+- Primary color: Deep navy (#013A5E) for a more modern look.
 - Background color: Soft off-white (#F5F7FA) to keep pages light and uncluttered.
-- Accent color: Metallic gold (#CBA135) for subtle highlights.
-- Body font: 'PT Sans', sans-serif. Use 'Playfair Display', serif for headlines to add elegance.
+- Accent color: Turquoise (#1ABC9C) for a fresh highlight.
+- Body font: 'Inter', sans-serif. Use 'Montserrat', sans-serif for headlines to keep it clean.
 - Use simple, professional icons that align with a clean user interface and are related to appointments and health records.
 - Maintain a clean, spacious, and organized layout that prioritizes information clarity and is accessible. Minimize visual clutter.
 - Subtle transitions and animations should be used sparingly to enhance user interaction without being distracting.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,7 +13,7 @@
     --popover: 0 0% 100%;
     --popover-foreground: 210 40% 20%;
 
-    --primary: 205 98% 26%; /* Dark petrol blue */
+    --primary: 210 70% 24%; /* Deep navy */
     --primary-foreground: 210 40% 95%;
 
     --secondary: 210 25% 90%;
@@ -22,7 +22,7 @@
     --muted: 210 25% 85%;
     --muted-foreground: 210 20% 40%;
 
-    --accent: 43 59% 50%; /* Metallic gold */
+    --accent: 177 70% 45%; /* Turquoise */
     --accent-foreground: 210 40% 15%;
 
     --destructive: 0 84.2% 60.2%;
@@ -39,7 +39,7 @@
     --sidebar-foreground: 210 40% 20%;
     --sidebar-primary: 205 98% 26%;
     --sidebar-primary-foreground: 210 40% 95%;
-    --sidebar-accent: 43 59% 50%;
+    --sidebar-accent: 177 70% 45%;
     --sidebar-accent-foreground: 210 40% 15%;
     --sidebar-border: 210 30% 85%;
     --sidebar-ring: 197 60% 60%;
@@ -61,7 +61,7 @@
     --popover: 220 25% 12%;
     --popover-foreground: 210 40% 96%;
 
-    --primary: 205 98% 60%;
+    --primary: 210 70% 60%;
     --primary-foreground: 205 20% 15%;
 
     --secondary: 220 20% 25%;
@@ -70,8 +70,8 @@
     --muted: 220 15% 25%;
     --muted-foreground: 210 30% 70%;
 
-    --accent: 43 70% 60%;
-    --accent-foreground: 43 100% 15%;
+    --accent: 177 70% 55%;
+    --accent-foreground: 177 100% 15%;
 
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
@@ -85,8 +85,8 @@
     --sidebar-foreground: 210 40% 96%;
     --sidebar-primary: 205 98% 60%;
     --sidebar-primary-foreground: 205 20% 15%;
-    --sidebar-accent: 43 70% 60%;
-    --sidebar-accent-foreground: 43 100% 15%;
+    --sidebar-accent: 177 70% 55%;
+    --sidebar-accent-foreground: 177 100% 15%;
     --sidebar-border: 220 20% 18%;
     --sidebar-ring: 197 60% 50%;
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,7 +28,7 @@ export default function RootLayout({
           crossOrigin="anonymous"
         />
         <link
-          href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=PT+Sans:wght@400;700&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Montserrat:wght@400;700&display=swap"
           rel="stylesheet"
         />
         <link rel="icon" href="/favicon.ico" />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,8 +11,8 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        body: ['PT Sans', 'sans-serif'],
-        headline: ['Playfair Display', 'serif'],
+        body: ['Inter', 'sans-serif'],
+        headline: ['Montserrat', 'sans-serif'],
         code: ['monospace'],
       },
       colors: {


### PR DESCRIPTION
## Summary
- switch default fonts to Inter and Montserrat
- update Google Fonts import
- refresh primary and accent colors to deep navy and turquoise
- document new style guidelines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843a93e9a5c8324a0e9961bb15c0ff9