### PR TITLE
Add demo data seeding script

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ CRYPTO_SECRET_KEY=REPLACE_ME_BASE64_32BYTES
 
 Todos os dados de pacientes são criptografados no cliente usando AES antes de serem manipulados.
 
+## Seeding com dados de exemplo
+
+Para popular o Firestore com dados fictícios, defina as variáveis `FIREBASE_SERVICE_ACCOUNT` e `CRYPTO_SECRET_KEY` em seu ambiente.
+Em seguida execute:
+
+```bash
+npx ts-node src/scripts/seed-demo-data.ts
+```
+
+Isso criará coleções como `patients`, `appointments`, `tasks` e outras com registros de demonstração.
+
 ## Sidebar
 
 O botão que alterna a sidebar (ícone de menu) só aparece em telas pequenas graças à classe `lg:hidden`.

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -11,6 +11,7 @@ import type {
   Medication,
   SymptomHeatmapEntry,
   FormulationDiagram,
+  Task,
   // outros tipos aqui
 } from "@/lib/types";
 import { encryptPatient, decryptPatient } from "./patientCrypto";
@@ -452,5 +453,48 @@ export const mockFormulations: FormulationDiagram[] = [
         { label: "Comportamentos", children: [{ label: "Isolamento" }] },
       ],
     }),
+  },
+];
+
+// ✅ Tarefas exemplo
+export const mockTasks: Task[] = [
+  {
+    id: "task-001",
+    patientId: "patient-001",
+    title: "Preparar relatório inicial",
+    description: "Resumo das primeiras sessões",
+    priority: "high",
+    taskType: "report",
+    dueDate: new Date(addDays(today, 2)).toISOString(),
+    status: "pending",
+    createdAt: today.toISOString(),
+    updatedAt: today.toISOString(),
+    createdBy: mockUser.id,
+  },
+  {
+    id: "task-002",
+    patientId: "patient-002",
+    title: "Enviar exercício de respiração",
+    description: "Compartilhar PDF por e-mail",
+    priority: "medium",
+    taskType: "session",
+    dueDate: new Date(addDays(today, 1)).toISOString(),
+    status: "pending",
+    createdAt: today.toISOString(),
+    updatedAt: today.toISOString(),
+    createdBy: mockUser.id,
+  },
+  {
+    id: "task-003",
+    patientId: null,
+    title: "Revisar políticas da clínica",
+    description: "Atualizar documentos de privacidade",
+    priority: "low",
+    taskType: "admin",
+    dueDate: new Date(addDays(today, 7)).toISOString(),
+    status: "pending",
+    createdAt: today.toISOString(),
+    updatedAt: today.toISOString(),
+    createdBy: mockUser.id,
   },
 ];

--- a/src/scripts/seed-demo-data.ts
+++ b/src/scripts/seed-demo-data.ts
@@ -1,0 +1,44 @@
+import admin from 'firebase-admin';
+import {
+  mockPatients,
+  mockAppointments,
+  mockWaitingList,
+  mockFinanceRecords,
+  mockTemplates,
+  mockKnowledgeBaseArticles,
+  mockMedications,
+  mockSymptomEntries,
+  mockFormulations,
+  mockTasks,
+} from '../lib/mock-data';
+
+function init() {
+  const sa = process.env.FIREBASE_SERVICE_ACCOUNT;
+  if (!sa) {
+    console.error('FIREBASE_SERVICE_ACCOUNT env var is required');
+    process.exit(1);
+  }
+  admin.initializeApp({ credential: admin.credential.cert(JSON.parse(sa)) });
+  return admin.firestore();
+}
+
+async function seed() {
+  const db = init();
+  const batch = db.batch();
+
+  mockPatients.forEach(p => batch.set(db.collection('patients').doc(p.id), p));
+  mockAppointments.forEach(a => batch.set(db.collection('appointments').doc(a.id), a));
+  mockWaitingList.forEach(w => batch.set(db.collection('waitingList').doc(w.id), w));
+  mockFinanceRecords.forEach(f => batch.set(db.collection('financeRecords').doc(f.id), f));
+  mockTemplates.forEach(t => batch.set(db.collection('templates').doc(t.id), t));
+  mockKnowledgeBaseArticles.forEach(k => batch.set(db.collection('knowledgeBase').doc(k.id), k));
+  mockMedications.forEach(m => batch.set(db.collection('medications').doc(m.id), m));
+  mockSymptomEntries.forEach(s => batch.set(db.collection('symptomEntries').doc(s.id), s));
+  mockFormulations.forEach(f => batch.set(db.collection('formulations').doc(f.sessionId), f));
+  mockTasks.forEach(t => batch.set(db.collection('tasks').doc(t.id), t));
+
+  await batch.commit();
+  console.log('Demo data seeded');
+}
+
+seed();


### PR DESCRIPTION
## Summary
- add `mockTasks` dataset
- seed Firestore with demo data
- document seeding script in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6843adfcf93c8324a842decaa0bb78c6