### PR TITLE
Add centralized navigation

### DIFF
--- a/src/app/(app)/appointments/calendar/page.tsx
+++ b/src/app/(app)/appointments/calendar/page.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+export default function AppointmentsCalendar() {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold font-headline">Calendário de Sessões</h1>
+      <p className="text-muted-foreground">Visualização do calendário em construção.</p>
+    </div>
+  );
+}

--- a/src/app/(app)/appointments/waiting/page.tsx
+++ b/src/app/(app)/appointments/waiting/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../waiting-list/page";

--- a/src/app/(app)/finance/page.tsx
+++ b/src/app/(app)/finance/page.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+export default function FinancePage() {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold font-headline">Financeiro</h1>
+      <p className="text-muted-foreground">Módulo financeiro em construção.</p>
+    </div>
+  );
+}

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -3,9 +3,9 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
-import Sidebar from '@/components/layout/Sidebar';
+import { Sidebar } from '@/components/navigation/Sidebar';
 import { AppHeader } from '@/components/layout/Header';
-import { TopTabs } from '@/components/layout/TopTabs';
+import { ContextTabs } from '@/components/navigation/ContextTabs';
 
 
 export default function AppLayout({
@@ -38,7 +38,7 @@ export default function AppLayout({
       <Sidebar />
       <div className="flex flex-1 flex-col">
         <AppHeader />
-        <TopTabs />
+        <ContextTabs />
         <main className="flex-1 overflow-y-auto bg-background p-8 md:p-12">
           {children}
         </main>

--- a/src/app/(app)/settings/features/page.tsx
+++ b/src/app/(app)/settings/features/page.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { features } from "@/data/navigation";
+import Link from "next/link";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export default function FeaturesPage() {
+  const grouped = features.reduce<Record<string, typeof features>>( (acc, f) => {
+    acc[f.category] = acc[f.category] || [];
+    acc[f.category].push(f);
+    return acc;
+  }, {} );
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold font-headline">Funcionalidades</h1>
+      {Object.entries(grouped).map(([category, items]) => (
+        <div key={category} className="space-y-2">
+          <h2 className="text-xl font-semibold">{category}</h2>
+          <div className="grid md:grid-cols-2 gap-4">
+            {items.map((f) => (
+              <Card key={f.href} className="hover:shadow-md">
+                <CardHeader>
+                  <CardTitle className="text-base">{f.label}</CardTitle>
+                  <CardDescription>{f.description}</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <Link href={f.href} className="text-sm text-primary underline">
+                    Acessar
+                  </Link>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/navigation/ContextTabs.tsx
+++ b/src/components/navigation/ContextTabs.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { routeTabs } from "@/data/navigation";
+import { usePathname, useRouter } from "next/navigation";
+
+export function ContextTabs() {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const cfg = routeTabs.find((c) => c.pattern.test(pathname));
+  if (!cfg) return null;
+
+  const match = pathname.match(cfg.pattern);
+  const params: Record<string, string> = {};
+  if (match && match.length > 1) {
+    params.id = match[1];
+  }
+
+  const tabs = cfg.getTabs(params);
+  const value = tabs.find((t) => pathname === t.href)?.href ?? tabs[0].href;
+
+  return (
+    <Tabs value={value} onValueChange={(href) => router.push(href)} className="px-4">
+      <TabsList>
+        {tabs.map((t) => (
+          <TabsTrigger key={t.href} value={t.href} className="capitalize">
+            {t.label}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+    </Tabs>
+  );
+}

--- a/src/components/navigation/Sidebar.tsx
+++ b/src/components/navigation/Sidebar.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { sidebarItems } from "@/data/navigation";
+import { useAuth } from "@/contexts/AuthContext";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent, SheetPortal, SheetOverlay } from "@/components/ui/sheet";
+import { Menu } from "lucide-react";
+import { useState } from "react";
+
+function Items({ onSelect }: { onSelect?: () => void }) {
+  const pathname = usePathname();
+  const { user } = useAuth();
+  const role = user?.role === "ADMIN" ? "admin" : "psychologist";
+
+  const items = sidebarItems.filter(
+    (i) => i.role === "all" || i.role === role,
+  );
+
+  return (
+    <nav className="flex flex-col gap-1 p-4">
+      {items.map((item) => {
+        const Icon = item.icon;
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            onClick={onSelect}
+            className={cn(
+              "flex items-center gap-2 rounded-md px-3 py-2 hover:bg-primary/15",
+              pathname === item.href && "bg-primary/15 font-semibold",
+            )}
+          >
+            <Icon className="h-4 w-4" />
+            <span>{item.label}</span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+
+export function Sidebar() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <div className="lg:hidden">
+        <Button variant="ghost" size="icon" onClick={() => setOpen(true)}>
+          <Menu className="h-5 w-5" />
+        </Button>
+      </div>
+      <aside className="hidden lg:flex w-56 flex-col border-r bg-card">
+        <Items />
+      </aside>
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetPortal>
+          <SheetOverlay className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50" />
+          <SheetContent side="left" className="p-0 w-56 bg-background">
+            <Items onSelect={() => setOpen(false)} />
+          </SheetContent>
+        </SheetPortal>
+      </Sheet>
+    </>
+  );
+}

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -1,0 +1,90 @@
+import { Home, Calendar, Users, DollarSign, Settings } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+export type NavRole = "psychologist" | "admin" | "all";
+
+export interface SidebarItem {
+  label: string;
+  href: string;
+  icon: LucideIcon;
+  role: NavRole;
+}
+
+export interface TabItem {
+  label: string;
+  href: string;
+}
+
+export interface RouteTabConfig {
+  pattern: RegExp;
+  getTabs: (params: Record<string, string>) => TabItem[];
+}
+
+export interface FeatureItem {
+  label: string;
+  description: string;
+  href: string;
+  category: "Atendimento" | "Administração" | "Ferramentas Extras";
+}
+
+export const sidebarItems: SidebarItem[] = [
+  { label: "Início", href: "/", icon: Home, role: "all" },
+  { label: "Agenda", href: "/appointments", icon: Calendar, role: "psychologist" },
+  { label: "Pacientes", href: "/patients", icon: Users, role: "psychologist" },
+  { label: "Financeiro", href: "/finance", icon: DollarSign, role: "admin" },
+  { label: "Configurações", href: "/settings", icon: Settings, role: "all" },
+];
+
+export const routeTabs: RouteTabConfig[] = [
+  {
+    pattern: /^\/patients\/([^/]+)/,
+    getTabs: ({ id }) => [
+      { label: "Ficha", href: `/patients/${id}` },
+      { label: "Notas", href: `/patients/${id}/notes` },
+      { label: "Relatórios", href: `/patients/${id}/reports` },
+      { label: "Mensurações", href: `/patients/${id}/metrics` },
+      { label: "AI Insights", href: `/patients/${id}/ai` },
+    ],
+  },
+  {
+    pattern: /^\/appointments/,
+    getTabs: () => [
+      { label: "Semanal", href: "/appointments" },
+      { label: "Calendário", href: "/appointments/calendar" },
+      { label: "Espera", href: "/waiting-list" },
+    ],
+  },
+];
+
+export const features: FeatureItem[] = [
+  {
+    category: "Atendimento",
+    label: "Agenda de Consultas",
+    description: "Gerencie sua agenda semanal e visualize pacientes em espera.",
+    href: "/appointments",
+  },
+  {
+    category: "Atendimento",
+    label: "Cadastro de Pacientes",
+    description: "Registre e acompanhe dados clínicos completos.",
+    href: "/patients",
+  },
+  {
+    category: "Administração",
+    label: "Financeiro",
+    description: "Controle receitas, despesas e relatórios contábeis.",
+    href: "/finance",
+  },
+  {
+    category: "Administração",
+    label: "Configurações",
+    description: "Ajuste preferências e integrações do sistema.",
+    href: "/settings",
+  },
+  {
+    category: "Ferramentas Extras",
+    label: "AI Insights",
+    description: "Analise notas clínicas com auxílio de IA.",
+    href: "/patients",
+  },
+];


### PR DESCRIPTION
## Summary
- centralize sidebar, tabs and features in `src/data/navigation.ts`
- create responsive `Sidebar` and `ContextTabs` components under `components/navigation`
- expose feature catalog at `/settings/features`
- add a placeholder finance module
- wire new navigation into app layout
- stub routes for appointments calendar and waiting view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843ae1737248324b04db6db2305bec2