### PR TITLE
Fix client directive positions

### DIFF
--- a/src/app/(app)/waiting-list/page.tsx
+++ b/src/app/(app)/waiting-list/page.tsx
@@ -1,4 +1,3 @@
-
 "use client";
 
 import { useState, useEffect } from 'react';

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -1,6 +1,5 @@
-
-// src/app/(auth)/register/page.tsx
 "use client";
+// src/app/(auth)/register/page.tsx
 
 // Placeholder for Registration Page
 import { useState } from 'react';

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,3 @@
-
 "use client";
 
 import { useEffect } from 'react';

--- a/src/components/appointments/AppointmentFormDialog.tsx
+++ b/src/components/appointments/AppointmentFormDialog.tsx
@@ -97,66 +97,6 @@ export function AppointmentFormDialog({
   const [patientQuery, setPatientQuery] = useState('');
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [phoneError, setPhoneError] = useState<string | null>(null);
-"use client";
-
-import type { Appointment, Patient, AttendanceStatus } from "@/lib/types";
-import { useState } from "react";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import {
-  Calendar as CalendarIcon,
-  CheckCircle,
-  XCircle,
-  Ban,
-  Edit3,
-  Trash2,
-  Clock,
-  User,
-  AlertCircle,
-  Info,
-  Phone,
-  MessageCircle,
-  History,
-} from "lucide-react";
-import {
-  format,
-  parseISO,
-  isSameDay,
-  isPast,
-  isToday,
-  addMinutes,
-} from "date-fns";
-import { ptBR } from "date-fns/locale";
-import { Calendar } from "@/components/ui/calendar";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { SmartModal } from "@/components/SmartModal";
-import { useToast } from "@/hooks/use-toast";
-import { Badge } from "@/components/ui/badge";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import Link from "next/link";
-import { useAuth } from "@/contexts/AuthContext";
-import { cn } from "@/lib/utils";
-import { useSettings } from "@/contexts/SettingsContext";
-import { BlockTimeDialog } from "@/components/BlockTimeDialog";
-import { AppointmentHistoryModal } from "@/components/AppointmentHistoryModal";
-
 const { system } = useSettings();
 const { toast } = useToast();
 

--- a/src/components/auth/RoleGate.tsx
+++ b/src/components/auth/RoleGate.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useAuth } from '@/contexts/AuthContext';
 import type { UserRole } from '@/lib/types';
 import React from 'react';

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,4 +1,3 @@
-
 "use client";
 
 import type { User } from '@/lib/types';

--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768


### PR DESCRIPTION
## Summary
- move `"use client"` directives to the first line of several TSX files
- clean up duplicate imports in `AppointmentFormDialog`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*
- `npm run typecheck` *(fails: TS1128 in AppointmentFormDialog)*

------
https://chatgpt.com/codex/tasks/task_e_6843b7fe668c8324933ac3dc51aeeb59