### PR TITLE
Fix profile menu toggle

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -82,7 +82,6 @@ export function AppHeader() {
             <DropdownMenuTrigger asChild>
               <Button
                 ref={buttonRef}
-                onClick={menu.toggle}
                 variant="ghost"
                 className="relative h-10 w-10 rounded-full"
                 title="Menu do perfil"


### PR DESCRIPTION
## Summary
- remove extraneous click handler from the profile menu button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843bdad6f9883248f0dcc5d37e6b0e2