### PR TITLE
Add treatment plan field

### DIFF
--- a/src/components/patients/PatientDetailsClient.tsx
+++ b/src/components/patients/PatientDetailsClient.tsx
@@ -12,6 +12,7 @@ import Link from "next/link";
 import { SessionNotesSection } from "./SessionNotesSection";
 import { AIInsightsSection } from "./AIInsightsSection";
 import { PatientFormDialog } from "./PatientFormDialog";
+import { TreatmentPlanSection } from "./TreatmentPlanSection";
 import { format, parseISO, differenceInYears } from "date-fns";
 import { useToast } from "@/hooks/use-toast";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -127,6 +128,20 @@ export function PatientDetailsClient({ patientId }: PatientDetailsClientProps) {
     });
   };
 
+  const handleSaveTreatmentPlan = async (plan: string) => {
+    if (!patient) return;
+    setPatient(prev => {
+      if (!prev) return null;
+      const updated = { ...prev, treatmentPlan: plan };
+      updateMockPatient(updated);
+      return updated;
+    });
+    toast({
+      title: "Plano Atualizado",
+      description: "O plano terapêutico foi salvo com sucesso.",
+    });
+  };
+
   const handleSavePatient = (updatedPatient: Patient) => {
     setPatient(updatedPatient);
     updateMockPatient(updatedPatient);
@@ -163,6 +178,21 @@ export function PatientDetailsClient({ patientId }: PatientDetailsClientProps) {
       </TabsList>
       <TabsContent value="details">
         {/* conteúdo completo mantido */}
+        <TreatmentPlanSection patient={patient} onSave={handleSaveTreatmentPlan} />
+        <SessionNotesSection
+          patient={patient}
+          onAddNote={handleAddNote}
+          onDeleteNote={handleDeleteNote}
+          onEditNote={handleEditNote}
+        />
+        <AIInsightsSection
+          patient={patient}
+          latestSessionNote={
+            patient.sessionNotes.length > 0
+              ? patient.sessionNotes[patient.sessionNotes.length - 1]
+              : undefined
+          }
+        />
       </TabsContent>
       <TabsContent value="audio">
         <VoiceSessionRecorder patient={patient} />

--- a/src/components/patients/PatientFormDialog.tsx
+++ b/src/components/patients/PatientFormDialog.tsx
@@ -35,6 +35,7 @@ const patientFormSchema = z.object({
   contact: z.string().min(5, { message: "Contato inválido." }), // Can be email or phone
   cpf: z.string().length(11, { message: "CPF deve ter 11 dígitos." }),
   dateOfBirth: z.date({ required_error: "Data de nascimento é obrigatória." }),
+  treatmentPlan: z.string().optional(),
 });
 
 type PatientFormValues = z.infer<typeof patientFormSchema>;
@@ -57,15 +58,30 @@ export function PatientFormDialog({ patient, onSave, children, isOpen: controlle
   const form = useForm<PatientFormValues>({
     resolver: zodResolver(patientFormSchema),
     defaultValues: patient
-      ? { ...patient, dateOfBirth: patient.dateOfBirth ? parseISO(patient.dateOfBirth) : new Date() }
-      : { name: "", contact: "", cpf: "", dateOfBirth: undefined },
+      ? {
+          ...patient,
+          dateOfBirth: patient.dateOfBirth
+            ? parseISO(patient.dateOfBirth)
+            : new Date(),
+        }
+      : {
+          name: "",
+          contact: "",
+          cpf: "",
+          dateOfBirth: undefined,
+          treatmentPlan: "",
+        },
   });
   
   React.useEffect(() => {
     if (patient) {
-      form.reset({ ...patient, dateOfBirth: patient.dateOfBirth ? parseISO(patient.dateOfBirth) : new Date() });
+      form.reset({
+        ...patient,
+        dateOfBirth: patient.dateOfBirth ? parseISO(patient.dateOfBirth) : new Date(),
+        treatmentPlan: patient.treatmentPlan || "",
+      });
     } else {
-      form.reset({ name: "", contact: "", cpf: "", dateOfBirth: undefined });
+      form.reset({ name: "", contact: "", cpf: "", dateOfBirth: undefined, treatmentPlan: "" });
     }
   }, [patient, form, isOpen]);
 
@@ -80,6 +96,7 @@ export function PatientFormDialog({ patient, onSave, children, isOpen: controlle
       ...values,
       dateOfBirth: format(values.dateOfBirth, "yyyy-MM-dd"),
       sessionNotes: patient?.sessionNotes || [],
+      treatmentPlan: values.treatmentPlan || "",
     };
     onSave(patientData);
     setIsLoading(false);
@@ -178,6 +195,23 @@ export function PatientFormDialog({ patient, onSave, children, isOpen: controlle
                       />
                     </PopoverContent>
                   </Popover>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="treatmentPlan"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Plano Terapêutico</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      rows={4}
+                      placeholder="Objetivos e etapas do tratamento"
+                      {...field}
+                    />
+                  </FormControl>
                   <FormMessage />
                 </FormItem>
               )}

--- a/src/components/patients/TreatmentPlanSection.tsx
+++ b/src/components/patients/TreatmentPlanSection.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Textarea } from "@/components/ui/textarea";
+import { ClipboardList, Save, Loader2 } from "lucide-react";
+import type { Patient } from "@/lib/types";
+
+interface TreatmentPlanSectionProps {
+  patient: Patient;
+  onSave: (plan: string) => Promise<void>;
+}
+
+export function TreatmentPlanSection({ patient, onSave }: TreatmentPlanSectionProps) {
+  const [plan, setPlan] = useState<string>(patient.treatmentPlan || "");
+  const [isEditing, setIsEditing] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    await onSave(plan);
+    setIsSaving(false);
+    setIsEditing(false);
+  };
+
+  return (
+    <Card className="shadow-lg rounded-lg">
+      <CardHeader>
+        <div className="flex justify-between items-center">
+          <div>
+            <CardTitle className="text-xl font-headline flex items-center gap-2">
+              <ClipboardList className="h-5 w-5 text-primary" />
+              Plano Terapêutico
+            </CardTitle>
+            <CardDescription>
+              Defina objetivos e etapas do tratamento.
+            </CardDescription>
+          </div>
+          {!isEditing && (
+            <Button size="sm" onClick={() => setIsEditing(true)} className="shadow-md">
+              Editar
+            </Button>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        {isEditing ? (
+          <div className="space-y-3">
+            <Textarea
+              rows={6}
+              value={plan}
+              onChange={(e) => setPlan(e.target.value)}
+              placeholder="Ex: Reduzir episódios de ansiedade em 3 meses."
+            />
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setPlan(patient.treatmentPlan || "");
+                  setIsEditing(false);
+                }}
+                disabled={isSaving}
+              >
+                Cancelar
+              </Button>
+              <Button onClick={handleSave} disabled={isSaving || plan.trim() === ""}>
+                {isSaving ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <Save className="mr-2 h-4 w-4" />
+                )}
+                Salvar
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <p className="whitespace-pre-wrap leading-relaxed">
+            {patient.treatmentPlan || "Nenhum plano definido."}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -95,6 +95,7 @@ export let mockPatients: Patient[] = [
     cpf: "12345678901",
     dateOfBirth: "1990-05-15",
     sessionNotes: initialSessionNotesP1,
+    treatmentPlan: "Reduzir episódios de ansiedade em 3 meses.",
     psychologistId: mockUser.id,
   }),
   encryptPatient({
@@ -104,6 +105,7 @@ export let mockPatients: Patient[] = [
     cpf: "98765432100",
     dateOfBirth: "1985-11-20",
     sessionNotes: initialSessionNotesP2,
+    treatmentPlan: "Melhorar habilidades de enfrentamento em 6 meses.",
     psychologistId: mockUser.id,
   }),
   encryptPatient({
@@ -113,6 +115,7 @@ export let mockPatients: Patient[] = [
     cpf: "11122233344",
     dateOfBirth: "2000-02-10",
     sessionNotes: [],
+    treatmentPlan: "Aumentar autoestima e confiança em 4 meses.",
     psychologistId: mockUser.id,
   }),
   encryptPatient({
@@ -122,6 +125,7 @@ export let mockPatients: Patient[] = [
     cpf: "22233344455",
     dateOfBirth: "1974-02-23",
     sessionNotes: initialSessionNotesP3,
+    treatmentPlan: "Trabalhar traumas passados em 5 meses.",
     psychologistId: mockUser.id,
   }),
 ];

--- a/src/lib/patientCrypto.ts
+++ b/src/lib/patientCrypto.ts
@@ -30,6 +30,7 @@ export function encryptPatient(patient: Patient): Patient {
     cpf: patient.cpf ? encrypt(patient.cpf) : undefined,
     dateOfBirth: encrypt(patient.dateOfBirth),
     sessionNotes: patient.sessionNotes.map(encNote),
+    treatmentPlan: patient.treatmentPlan ? encrypt(patient.treatmentPlan) : undefined,
   };
 }
 
@@ -42,6 +43,7 @@ export function decryptPatient(patient: Patient): Patient {
     cpf: patient.cpf ? decrypt(patient.cpf) : undefined,
     dateOfBirth: decrypt(patient.dateOfBirth),
     sessionNotes: patient.sessionNotes.map(decNote),
+    treatmentPlan: patient.treatmentPlan ? decrypt(patient.treatmentPlan) : undefined,
   };
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -38,6 +38,7 @@ export interface Patient {
   cpf?: string;
   dateOfBirth: string; // ISO 8601
   sessionNotes: SessionNote[];
+  treatmentPlan?: string;
   psychologistId?: string;
 }
 

--- a/tests/patientCrypto.test.ts
+++ b/tests/patientCrypto.test.ts
@@ -25,6 +25,7 @@ const patient: Patient = {
       sessionTags: ['teste'],
     },
   ],
+  treatmentPlan: 'Plano inicial',
 };
 
 test('encryptPatient/decryptPatient roundtrip', () => {


### PR DESCRIPTION
## Summary
- add TreatmentPlanSection component to edit patient goals
- store treatment plans in patient data and encrypt/decrypt them
- extend patient form to include treatment plan
- update mock data and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843c6b12af48324b0fc6b7d07ef1228