### PR TITLE
Add features overview page

### DIFF
--- a/src/app/(app)/settings/features/page.tsx
+++ b/src/app/(app)/settings/features/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { features } from "@/lib/navigation";
+import { features } from "@/lib/features";
 import Link from "next/link";
 import {
   Card,

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -54,6 +54,7 @@ function SidebarContent({
     '/analytics': LineChart,
     '/analytics/psychologist': LineChart,
     '/settings': Settings,
+    '/settings/features': FileText,
     '/user-approvals': Users,
   };
 

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -1,0 +1,69 @@
+export interface Feature {
+  category: string;
+  label: string;
+  description: string;
+  href: string;
+}
+
+export const features: Feature[] = [
+  {
+    category: 'Sessões',
+    label: 'Agenda de Consultas',
+    description: 'Gerencie seus horários e crie novas sessões.',
+    href: '/appointments',
+  },
+  {
+    category: 'Sessões',
+    label: 'Lista de Espera',
+    description: 'Acompanhe pacientes aguardando vagas.',
+    href: '/waiting-list',
+  },
+  {
+    category: 'Pacientes',
+    label: 'Cadastro de Pacientes',
+    description: 'Registre dados clínicos e histórico completo.',
+    href: '/patients',
+  },
+  {
+    category: 'Pacientes',
+    label: 'Biblioteca de Inventários',
+    description: 'Aplique avaliações e registre resultados.',
+    href: '/assessments/library',
+  },
+  {
+    category: 'Relatórios',
+    label: 'Painel Analítico',
+    description: 'Visualize métricas e evolução dos atendimentos.',
+    href: '/analytics',
+  },
+  {
+    category: 'Relatórios',
+    label: 'Indicadores do Psicólogo',
+    description: 'Dados de desempenho individual.',
+    href: '/analytics/psychologist',
+  },
+  {
+    category: 'Integrações',
+    label: 'Exportação de Agenda',
+    description: 'Sincronize compromissos com calendários externos.',
+    href: '/settings',
+  },
+  {
+    category: 'Configurações',
+    label: 'Preferências do Sistema',
+    description: 'Defina horários e opções globais.',
+    href: '/settings',
+  },
+  {
+    category: 'Segurança',
+    label: 'Gerenciamento de Usuários',
+    description: 'Aprovação e controle de permissões.',
+    href: '/user-approvals',
+  },
+  {
+    category: 'Segurança',
+    label: 'Criptografia de Dados',
+    description: 'Protege informações sensíveis dos pacientes.',
+    href: '/dashboard',
+  },
+];

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -33,12 +33,6 @@ export interface RouteTabConfig {
   getTabs: (params: Record<string, string>) => TabItem[];
 }
 
-export interface FeatureItem {
-  label: string;
-  description: string;
-  href: string;
-  category: "Atendimento" | "Administração" | "Ferramentas Extras";
-}
 
 export const navigation: NavItem[] = [
   {
@@ -108,6 +102,12 @@ export const navigation: NavItem[] = [
     category: 'Sistema',
   },
   {
+    label: 'Funcionalidades',
+    description: 'Mapa das ferramentas dispon\u00edveis no sistema.',
+    href: '/settings/features',
+    category: 'Sistema',
+  },
+  {
     label: 'Aprovar Usu\u00e1rios',
     description: 'Gerencie solicita\u00e7\u00f5es de acesso de novos profissionais.',
     href: '/user-approvals',
@@ -144,35 +144,3 @@ export const routeTabs: RouteTabConfig[] = [
   },
 ];
 
-export const features: FeatureItem[] = [
-  {
-    category: 'Atendimento',
-    label: 'Agenda de Consultas',
-    description: 'Gerencie sua agenda semanal e visualize pacientes em espera.',
-    href: '/appointments',
-  },
-  {
-    category: 'Atendimento',
-    label: 'Cadastro de Pacientes',
-    description: 'Registre e acompanhe dados cl\u00ednicos completos.',
-    href: '/patients',
-  },
-  {
-    category: 'Administra\u00e7\u00e3o',
-    label: 'Financeiro',
-    description: 'Controle receitas, despesas e relat\u00f3rios cont\u00e1beis.',
-    href: '/finance',
-  },
-  {
-    category: 'Administra\u00e7\u00e3o',
-    label: 'Configura\u00e7\u00f5es',
-    description: 'Ajuste prefer\u00eancias e integra\u00e7\u00f5es do sistema.',
-    href: '/settings',
-  },
-  {
-    category: 'Ferramentas Extras',
-    label: 'AI Insights',
-    description: 'Analise notas cl\u00ednicas com aux\u00edlio de IA.',
-    href: '/patients',
-  },
-];


### PR DESCRIPTION
## Summary
- centralize feature descriptions in `src/lib/features.ts`
- update settings page to use new features object
- add "Funcionalidades" entry in navigation and sidebar icon map

## Testing
- `npm run lint` *(fails: requires Next.js ESLint setup)*
- `npm run typecheck` *(fails: several TS errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843c5e641488324be32fdf7fb971f66