### PR TITLE
Disable auth requirement for demo

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -82,16 +82,19 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
           console.error('Failed to load user profile', err);
           setUser(null);
         }
-      } else {
-        const storedUser = localStorage.getItem('psiguard_user');
-        if (storedUser) {
-          setUser(JSON.parse(storedUser));
         } else {
-          setUser(null);
+          const storedUser = localStorage.getItem('psiguard_user');
+          if (storedUser) {
+            setUser(JSON.parse(storedUser));
+          } else {
+            const autoUser = { ...mockUser, sessionId: crypto.randomUUID() };
+            setUser(autoUser);
+            localStorage.setItem('psiguard_user', JSON.stringify(autoUser));
+            localStorage.setItem(SESSION_KEY, autoUser.sessionId);
+          }
         }
-      }
-      setIsLoading(false);
-    });
+        setIsLoading(false);
+      });
     return () => unsubscribe();
   }, []);
 


### PR DESCRIPTION
## Summary
- auto-login with mock user when no stored credentials

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ce1979b483248a190570c7e62297