### PR TITLE
Enable coverage reporting

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,14 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   roots: ['<rootDir>/tests'],
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+  },
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test": "jest"
+    "test": "jest --coverage"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.8.0",


### PR DESCRIPTION
## Summary
- add coverage reporting via Jest
- enforce coverage thresholds in config

## Testing
- `npm test` *(fails: coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_6843d07cb030832498d037d057603835