### PR TITLE
Add analytics & recurrence tests

### DIFF
--- a/src/lib/recurrence.ts
+++ b/src/lib/recurrence.ts
@@ -12,6 +12,11 @@ export function generateRecurringDates(start: Date | string, rule: RecurrenceRul
   const untilDate = rule.until ? (typeof rule.until === 'string' ? parseISO(rule.until) : rule.until) : null;
   const freqWeeks = rule.frequency === 'daily' ? 0 : rule.frequency === 'weekly' ? 1 : 2;
 
+  if (rule.count !== undefined && rule.count <= 0) return [];
+  if (untilDate && untilDate < startDate) return [];
+  const allowedWeekdays = rule.weekdays?.filter((d) => d >= 0 && d <= 6);
+  if (rule.weekdays && (!allowedWeekdays || allowedWeekdays.length === 0)) return [];
+
   let day = startOfWeek(startDate, { weekStartsOn: 0 });
   let added = 0;
   const maxIterations = 1000; // safety guard
@@ -22,7 +27,7 @@ export function generateRecurringDates(start: Date | string, rule: RecurrenceRul
     if (rule.count && added >= rule.count) break;
 
     if (current >= startDate) {
-      if (!rule.weekdays || rule.weekdays.includes(current.getDay())) {
+      if (!allowedWeekdays || allowedWeekdays.includes(current.getDay())) {
         if (
           freqWeeks === 0 ||
           differenceInCalendarWeeks(current, startDate, { weekStartsOn: 0 }) % freqWeeks === 0

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -1,0 +1,84 @@
+import { getWeeklySessionCounts, getProblemTypeCounts, getScheduleOccupancy } from '../src/lib/analytics';
+import { Appointment, Patient } from '../src/lib/types';
+import { addDays } from 'date-fns';
+
+const baseAppointment: Appointment = {
+  id: 'a1',
+  patientId: 'p1',
+  patientName: 'John',
+  dateTime: new Date('2024-01-01T10:00:00Z').toISOString(),
+  durationMinutes: 60,
+  status: 'pending',
+};
+
+const basePatient: Patient = {
+  id: 'p1',
+  name: 'John',
+  contact: '1',
+  dateOfBirth: '2000-01-01',
+  sessionNotes: [],
+};
+
+describe('getWeeklySessionCounts', () => {
+  it('returns empty array when there are no appointments', () => {
+    expect(getWeeklySessionCounts([])).toEqual([]);
+  });
+
+  it('groups appointments by ISO week starting on Monday', () => {
+    const appts: Appointment[] = [
+      baseAppointment,
+      {
+        ...baseAppointment,
+        id: 'a2',
+        dateTime: new Date('2024-01-03T10:00:00Z').toISOString(),
+      },
+      {
+        ...baseAppointment,
+        id: 'a3',
+        dateTime: new Date('2024-01-09T10:00:00Z').toISOString(),
+      },
+    ];
+    const counts = getWeeklySessionCounts(appts);
+    expect(counts).toEqual([
+      { week: '2024-01-01', count: 2 },
+      { week: '2024-01-08', count: 1 },
+    ]);
+  });
+});
+
+describe('getProblemTypeCounts', () => {
+  const patients: Patient[] = [
+    {
+      ...basePatient,
+      sessionNotes: [
+        { id: 'n1', date: '2024-01-01', notes: 'Paciente relata ansiedade.' },
+        { id: 'n2', date: '2024-01-02', notes: 'Sintomas de ajustamento.' },
+        { id: 'n3', date: '2024-01-03', notes: 'Nada relevante.' },
+      ],
+    },
+  ];
+
+  it('categorizes notes based on keywords with "outros" fallback', () => {
+    const counts = getProblemTypeCounts(patients);
+    expect(counts).toEqual({ ansiedade: 1, ajustamento: 1, outros: 1 });
+  });
+});
+
+describe('getScheduleOccupancy', () => {
+  const start = new Date('2024-01-01T00:00:00Z');
+  const end = addDays(start, 4); // five days
+
+  it('handles empty schedule', () => {
+    const occ = getScheduleOccupancy([], start, end);
+    expect(occ.scheduledMinutes).toBe(0);
+    expect(occ.freePercent).toBe(100);
+  });
+
+  it('calculates percentages with appointments', () => {
+    const appt = { ...baseAppointment };
+    const occ = getScheduleOccupancy([appt], start, end);
+    const totalMinutes = 5 * 8 * 60; // 5 days * 8 hours
+    expect(occ.scheduledMinutes).toBe(appt.durationMinutes);
+    expect(occ.scheduledPercent).toBeCloseTo((appt.durationMinutes / totalMinutes) * 100);
+  });
+});

--- a/tests/recurrence.test.ts
+++ b/tests/recurrence.test.ts
@@ -1,0 +1,47 @@
+import { generateRecurringDates, generateRecurringAppointments } from '../src/lib/recurrence';
+import { Appointment, RecurrenceRule } from '../src/lib/types';
+
+const baseAppointment: Appointment = {
+  id: 'appt',
+  patientId: 'p1',
+  patientName: 'John',
+  dateTime: '2024-01-01T10:00:00Z',
+  durationMinutes: 60,
+  status: 'pending',
+};
+
+describe('generateRecurringDates edge cases', () => {
+  it('returns empty array when count is 0', () => {
+    const rule: RecurrenceRule = { frequency: 'daily', count: 0 };
+    expect(generateRecurringDates(baseAppointment.dateTime, rule)).toEqual([]);
+  });
+
+  it('returns empty array when until is before start', () => {
+    const rule: RecurrenceRule = { frequency: 'weekly', until: '2023-12-30' };
+    expect(generateRecurringDates(baseAppointment.dateTime, rule)).toEqual([]);
+  });
+
+  it('handles weekly recurrence', () => {
+    const rule: RecurrenceRule = { frequency: 'weekly', weekdays: [2], count: 2 };
+    const dates = generateRecurringDates('2024-01-01T10:00:00Z', rule);
+    expect(dates.map((d) => d.toISOString().slice(0, 10))).toEqual([
+      '2024-01-02',
+      '2024-01-09',
+    ]);
+  });
+
+  it('ignores invalid weekday values', () => {
+    const rule = { frequency: 'weekly', weekdays: [7], count: 2 } as unknown as RecurrenceRule;
+    expect(generateRecurringDates(baseAppointment.dateTime, rule)).toEqual([]);
+  });
+});
+
+describe('generateRecurringAppointments', () => {
+  it('creates appointments mirroring generated dates', () => {
+    const rule: RecurrenceRule = { frequency: 'weekly', weekdays: [2], count: 1 };
+    const appts = generateRecurringAppointments(baseAppointment, rule);
+    expect(appts.length).toBe(1);
+    expect(appts[0].id).toBe('appt-0');
+    expect(appts[0].recurrenceId).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage tests for analytics functions
- add tests for recurrence utilities
- handle invalid recurrence rules

## Testing
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6843d089a1588324bdc4aa2a64b95590