### PR TITLE
Use Node crypto for GCM encryption

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,5 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
-import CryptoJS from 'crypto-js';
 import crypto from 'crypto';
 
 let cachedKey: Buffer | undefined;
@@ -30,8 +29,11 @@ export function cn(...inputs: ClassValue[]) {
  * @returns The encrypted string.
  */
 export function encrypt(text: string): string {
-  const key = getCryptoKey().toString('base64');
-  return CryptoJS.AES.encrypt(text, key).toString();
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv('aes-256-gcm', getCryptoKey(), iv);
+  const encrypted = Buffer.concat([cipher.update(text, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, tag, encrypted]).toString('base64');
 }
 
 /**
@@ -40,8 +42,14 @@ export function encrypt(text: string): string {
  * @returns The decrypted string.
  */
 export function decrypt(ciphertext: string): string {
-  const key = getCryptoKey().toString('base64');
-  return CryptoJS.AES.decrypt(ciphertext, key).toString(CryptoJS.enc.Utf8);
+  const data = Buffer.from(ciphertext, 'base64');
+  const iv = data.subarray(0, 12);
+  const tag = data.subarray(12, 28);
+  const text = data.subarray(28);
+  const decipher = crypto.createDecipheriv('aes-256-gcm', getCryptoKey(), iv);
+  decipher.setAuthTag(tag);
+  const decrypted = Buffer.concat([decipher.update(text), decipher.final()]);
+  return decrypted.toString('utf8');
 }
 
 // 🆔 Formata um CPF aplicando máscara 000.000.000-00

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -17,6 +17,12 @@ describe('encrypt/decrypt', () => {
     expect(cipher).not.toBe(plaintext);
   });
 
+  it('encrypt uses a random IV, producing different ciphertext each time', () => {
+    const c1 = encrypt(plaintext);
+    const c2 = encrypt(plaintext);
+    expect(c1).not.toBe(c2);
+  });
+
   it('decrypt(encrypt(text)) returns the original plaintext', () => {
     const cipher = encrypt(plaintext);
     const decrypted = decrypt(cipher);


### PR DESCRIPTION
## Summary
- replace CryptoJS AES with Node's `crypto` using GCM
- store IV + tag + ciphertext to support decrypt
- improve encryption tests to check IV randomness

## Testing
- `npx jest --runInBand` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6843ced928988324987372d89a73b041