### PR TITLE
Implement patient notification opt-out & logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ npx ts-node src/scripts/seed-demo-data.ts
 
 Isso criará coleções como `patients`, `appointments`, `tasks` e outras com registros de demonstração.
 
+## Controle de notificações
+
+Cada documento em `patients` pode conter o campo opcional `notificationsOptOut`:
+
+```json
+{
+  "notificationsOptOut": { "email": false, "sms": true }
+}
+```
+
+Quando definido, as funções de envio respeitam essas preferências e não enviam
+mensagens para os canais desativados. Todo envio é registrado na subcoleção
+`patients/{patientId}/notificationLog`.
+
 ## Sidebar
 
 O botão que alterna a sidebar (ícone de menu) só aparece em telas pequenas graças à classe `lg:hidden`.

--- a/functions/scheduleAppointmentReminder.ts
+++ b/functions/scheduleAppointmentReminder.ts
@@ -6,6 +6,31 @@ import twilio from 'twilio';
 admin.initializeApp();
 const db = admin.firestore();
 
+async function shouldSendNotification(patientId: string, message: string) {
+  const cutoff = admin.firestore.Timestamp.fromMillis(
+    Date.now() - 24 * 60 * 60 * 1000,
+  );
+  const snap = await db
+    .collection(`patients/${patientId}/notificationLog`)
+    .where('message', '==', message)
+    .where('createdAt', '>=', cutoff)
+    .limit(1)
+    .get();
+  return snap.empty;
+}
+
+async function logNotification(
+  patientId: string,
+  channel: string,
+  message: string,
+) {
+  await db.collection(`patients/${patientId}/notificationLog`).add({
+    channel,
+    message,
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+}
+
 sgMail.setApiKey(process.env.SENDGRID_API_KEY as string);
 const twilioClient = twilio(process.env.TWILIO_SID as string, process.env.TWILIO_AUTH_TOKEN as string);
 
@@ -20,11 +45,18 @@ async function notifyPatient(patientId: string, message: string) {
   const patient = patientSnap.data() as any;
   if (!patient) return;
   const contact = patient.contact;
+  const optOut = patient.notificationsOptOut || {};
   if (contact) {
-    if (contact.includes('@')) {
-      await sgMail.send({ to: contact, from: SENDGRID_FROM, subject: 'Lembrete de Sessão', text: message });
-    } else if (TWILIO_SMS_FROM) {
-      await twilioClient.messages.create({ from: TWILIO_SMS_FROM, to: contact, body: message });
+    if (contact.includes('@') && !optOut.email) {
+      if (await shouldSendNotification(patientId, message)) {
+        await sgMail.send({ to: contact, from: SENDGRID_FROM, subject: 'Lembrete de Sessão', text: message });
+        await logNotification(patientId, 'email', message);
+      }
+    } else if (TWILIO_SMS_FROM && !optOut.sms) {
+      if (await shouldSendNotification(patientId, message)) {
+        await twilioClient.messages.create({ from: TWILIO_SMS_FROM, to: contact, body: message });
+        await logNotification(patientId, 'sms', message);
+      }
     }
   }
 }

--- a/functions/scheduleAssessmentReminder.ts
+++ b/functions/scheduleAssessmentReminder.ts
@@ -6,6 +6,31 @@ import twilio from 'twilio';
 admin.initializeApp();
 const db = admin.firestore();
 
+async function shouldSendNotification(patientId: string, message: string) {
+  const cutoff = admin.firestore.Timestamp.fromMillis(
+    Date.now() - 24 * 60 * 60 * 1000,
+  );
+  const snap = await db
+    .collection(`patients/${patientId}/notificationLog`)
+    .where('message', '==', message)
+    .where('createdAt', '>=', cutoff)
+    .limit(1)
+    .get();
+  return snap.empty;
+}
+
+async function logNotification(
+  patientId: string,
+  channel: string,
+  message: string,
+) {
+  await db.collection(`patients/${patientId}/notificationLog`).add({
+    channel,
+    message,
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+}
+
 sgMail.setApiKey(process.env.SENDGRID_API_KEY as string);
 const twilioClient = twilio(process.env.TWILIO_SID as string, process.env.TWILIO_AUTH_TOKEN as string);
 
@@ -19,11 +44,18 @@ async function notify(patientId: string, message: string) {
   const patient = snap.data() as any;
   if (!patient) return;
   const contact = patient.contact;
+  const optOut = patient.notificationsOptOut || {};
   if (contact) {
-    if (contact.includes('@')) {
-      await sgMail.send({ to: contact, from: SENDGRID_FROM, subject: 'Lembrete de Inventário', text: message });
-    } else if (TWILIO_SMS_FROM) {
-      await twilioClient.messages.create({ from: TWILIO_SMS_FROM, to: contact, body: message });
+    if (contact.includes('@') && !optOut.email) {
+      if (await shouldSendNotification(patientId, message)) {
+        await sgMail.send({ to: contact, from: SENDGRID_FROM, subject: 'Lembrete de Inventário', text: message });
+        await logNotification(patientId, 'email', message);
+      }
+    } else if (TWILIO_SMS_FROM && !optOut.sms) {
+      if (await shouldSendNotification(patientId, message)) {
+        await twilioClient.messages.create({ from: TWILIO_SMS_FROM, to: contact, body: message });
+        await logNotification(patientId, 'sms', message);
+      }
     }
   }
 }

--- a/functions/sendAssessmentLink.ts
+++ b/functions/sendAssessmentLink.ts
@@ -7,6 +7,31 @@ import jwt from 'jsonwebtoken';
 admin.initializeApp();
 const db = admin.firestore();
 
+async function shouldSendNotification(patientId: string, message: string) {
+  const cutoff = admin.firestore.Timestamp.fromMillis(
+    Date.now() - 24 * 60 * 60 * 1000,
+  );
+  const snap = await db
+    .collection(`patients/${patientId}/notificationLog`)
+    .where('message', '==', message)
+    .where('createdAt', '>=', cutoff)
+    .limit(1)
+    .get();
+  return snap.empty;
+}
+
+async function logNotification(
+  patientId: string,
+  channel: string,
+  message: string,
+) {
+  await db.collection(`patients/${patientId}/notificationLog`).add({
+    channel,
+    message,
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+}
+
 sgMail.setApiKey(process.env.SENDGRID_API_KEY as string);
 const twilioClient = twilio(process.env.TWILIO_SID as string, process.env.TWILIO_AUTH_TOKEN as string);
 const TOKEN_SECRET = process.env.ASSESSMENT_TOKEN_SECRET;
@@ -25,22 +50,31 @@ async function internalSend(patientId: string, assessmentId: string, channels: s
   const patientSnap = await db.doc(`patients/${patientId}`).get();
   const patient = patientSnap.data();
   if (!patient) return;
+  const optOut = patient.notificationsOptOut || {};
 
-  if (channels.includes('email')) {
-    await sgMail.send({
-      to: patient.contact,
-      from: process.env.SENDGRID_FROM_EMAIL as string,
-      subject: 'Novo Inventário',
-      text: `Por favor, preencha: ${link}`,
-    });
+  if (channels.includes('email') && !optOut.email) {
+    const message = `Por favor, preencha: ${link}`;
+    if (await shouldSendNotification(patientId, message)) {
+      await sgMail.send({
+        to: patient.contact,
+        from: process.env.SENDGRID_FROM_EMAIL as string,
+        subject: 'Novo Inventário',
+        text: message,
+      });
+      await logNotification(patientId, 'email', message);
+    }
   }
 
-  if (channels.includes('whatsapp') && process.env.TWILIO_WHATSAPP_FROM) {
-    await twilioClient.messages.create({
-      from: process.env.TWILIO_WHATSAPP_FROM,
-      to: `whatsapp:${patient.contact}`,
-      body: `Preencha: ${link}`,
-    });
+  if (channels.includes('whatsapp') && process.env.TWILIO_WHATSAPP_FROM && !optOut.sms) {
+    const message = `Preencha: ${link}`;
+    if (await shouldSendNotification(patientId, message)) {
+      await twilioClient.messages.create({
+        from: process.env.TWILIO_WHATSAPP_FROM,
+        to: `whatsapp:${patient.contact}`,
+        body: message,
+      });
+      await logNotification(patientId, 'whatsapp', message);
+    }
   }
 }
 

--- a/functions/src/sendAssessmentLink.ts
+++ b/functions/src/sendAssessmentLink.ts
@@ -8,6 +8,34 @@ import jwt from 'jsonwebtoken';
 admin.initializeApp();
 const db = admin.firestore();
 
+async function shouldSendNotification(
+  patientId: string,
+  message: string,
+) {
+  const cutoff = admin.firestore.Timestamp.fromMillis(
+    Date.now() - 24 * 60 * 60 * 1000,
+  );
+  const snap = await db
+    .collection(`patients/${patientId}/notificationLog`)
+    .where('message', '==', message)
+    .where('createdAt', '>=', cutoff)
+    .limit(1)
+    .get();
+  return snap.empty;
+}
+
+async function logNotification(
+  patientId: string,
+  channel: string,
+  message: string,
+) {
+  await db.collection(`patients/${patientId}/notificationLog`).add({
+    channel,
+    message,
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+}
+
 sgMail.setApiKey(process.env.SENDGRID_API_KEY as string);
 const twilioClient = twilio(process.env.TWILIO_SID as string, process.env.TWILIO_AUTH_TOKEN as string);
 const TOKEN_SECRET = process.env.ASSESSMENT_TOKEN_SECRET as string;
@@ -23,22 +51,31 @@ async function internalSend(patientId: string, assessmentId: string, channels: s
   const patientSnap = await db.doc(`patients/${patientId}`).get();
   const patient = patientSnap.data();
   if (!patient) return;
+  const optOut = patient.notificationsOptOut || {};
 
-  if (channels.includes('email')) {
-    await sgMail.send({
-      to: patient.contact,
-      from: process.env.SENDGRID_FROM_EMAIL as string,
-      subject: 'Novo Inventário',
-      text: `Por favor, preencha: ${link}`,
-    });
+  if (channels.includes('email') && !optOut.email) {
+    const message = `Por favor, preencha: ${link}`;
+    if (await shouldSendNotification(patientId, message)) {
+      await sgMail.send({
+        to: patient.contact,
+        from: process.env.SENDGRID_FROM_EMAIL as string,
+        subject: 'Novo Inventário',
+        text: message,
+      });
+      await logNotification(patientId, 'email', message);
+    }
   }
 
-  if (channels.includes('whatsapp') && process.env.TWILIO_WHATSAPP_FROM) {
-    await twilioClient.messages.create({
-      from: process.env.TWILIO_WHATSAPP_FROM,
-      to: `whatsapp:${patient.contact}`,
-      body: `Preencha: ${link}`,
-    });
+  if (channels.includes('whatsapp') && process.env.TWILIO_WHATSAPP_FROM && !optOut.sms) {
+    const message = `Preencha: ${link}`;
+    if (await shouldSendNotification(patientId, message)) {
+      await twilioClient.messages.create({
+        from: process.env.TWILIO_WHATSAPP_FROM,
+        to: `whatsapp:${patient.contact}`,
+        body: message,
+      });
+      await logNotification(patientId, 'whatsapp', message);
+    }
   }
 }
 

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -97,6 +97,7 @@ export let mockPatients: Patient[] = [
     sessionNotes: initialSessionNotesP1,
     treatmentPlan: "Reduzir episódios de ansiedade em 3 meses.",
     psychologistId: mockUser.id,
+    notificationsOptOut: { email: false, sms: false },
   }),
   encryptPatient({
     id: "patient-002",
@@ -107,6 +108,7 @@ export let mockPatients: Patient[] = [
     sessionNotes: initialSessionNotesP2,
     treatmentPlan: "Melhorar habilidades de enfrentamento em 6 meses.",
     psychologistId: mockUser.id,
+    notificationsOptOut: { email: false, sms: false },
   }),
   encryptPatient({
     id: "patient-003",
@@ -117,6 +119,7 @@ export let mockPatients: Patient[] = [
     sessionNotes: [],
     treatmentPlan: "Aumentar autoestima e confiança em 4 meses.",
     psychologistId: mockUser.id,
+    notificationsOptOut: { email: false, sms: false },
   }),
   encryptPatient({
     id: "patient-004",
@@ -127,6 +130,7 @@ export let mockPatients: Patient[] = [
     sessionNotes: initialSessionNotesP3,
     treatmentPlan: "Trabalhar traumas passados em 5 meses.",
     psychologistId: mockUser.id,
+    notificationsOptOut: { email: false, sms: false },
   }),
 ];
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -40,6 +40,10 @@ export interface Patient {
   sessionNotes: SessionNote[];
   treatmentPlan?: string;
   psychologistId?: string;
+  notificationsOptOut?: {
+    email: boolean;
+    sms: boolean;
+  };
 }
 
 // 📅 Agendamento de sessão

--- a/tests/patientCrypto.test.ts
+++ b/tests/patientCrypto.test.ts
@@ -26,6 +26,7 @@ const patient: Patient = {
     },
   ],
   treatmentPlan: 'Plano inicial',
+  notificationsOptOut: { email: false, sms: false },
 };
 
 test('encryptPatient/decryptPatient roundtrip', () => {


### PR DESCRIPTION
## Summary
- track patient notifications in `notificationLog` subcollection
- respect `notificationsOptOut` field when sending
- prevent duplicate notifications within 24h
- extend Patient type and mock data
- document notification controls in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843d16efc408324b28bf8849f93c438