### PR TITLE
Add contact validators with tests

### DIFF
--- a/functions/scheduleAppointmentReminder.ts
+++ b/functions/scheduleAppointmentReminder.ts
@@ -1,13 +1,17 @@
-import * as functions from 'firebase-functions';
-import * as admin from 'firebase-admin';
-import sgMail from '@sendgrid/mail';
-import twilio from 'twilio';
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import sgMail from "@sendgrid/mail";
+import twilio from "twilio";
+import { isValidEmail, isValidE164 } from "./src/validators";
 
 admin.initializeApp();
 const db = admin.firestore();
 
 sgMail.setApiKey(process.env.SENDGRID_API_KEY as string);
-const twilioClient = twilio(process.env.TWILIO_SID as string, process.env.TWILIO_AUTH_TOKEN as string);
+const twilioClient = twilio(
+  process.env.TWILIO_SID as string,
+  process.env.TWILIO_AUTH_TOKEN as string,
+);
 
 const SENDGRID_FROM = process.env.SENDGRID_FROM_EMAIL as string;
 const TWILIO_SMS_FROM = process.env.TWILIO_SMS_FROM;
@@ -21,23 +25,42 @@ async function notifyPatient(patientId: string, message: string) {
   if (!patient) return;
   const contact = patient.contact;
   if (contact) {
-    if (contact.includes('@')) {
-      await sgMail.send({ to: contact, from: SENDGRID_FROM, subject: 'Lembrete de Sessão', text: message });
+    if (contact.includes("@")) {
+      if (isValidEmail(contact)) {
+        await sgMail.send({
+          to: contact,
+          from: SENDGRID_FROM,
+          subject: "Lembrete de Sessão",
+          text: message,
+        });
+      } else {
+        console.error("Contato de email inválido", contact);
+      }
     } else if (TWILIO_SMS_FROM) {
-      await twilioClient.messages.create({ from: TWILIO_SMS_FROM, to: contact, body: message });
+      if (isValidE164(contact)) {
+        await twilioClient.messages.create({
+          from: TWILIO_SMS_FROM,
+          to: contact,
+          body: message,
+        });
+      } else {
+        console.error("Contato de telefone inválido", contact);
+      }
     }
   }
 }
 
 async function processReminders(minutesBefore: number, flag: string) {
   const now = Date.now();
-  const targetStart = new Date(now + (minutesBefore - 1) * 60 * 1000).toISOString();
+  const targetStart = new Date(
+    now + (minutesBefore - 1) * 60 * 1000,
+  ).toISOString();
   const targetEnd = new Date(now + minutesBefore * 60 * 1000).toISOString();
   const snap = await db
-    .collection('appointments')
-    .where('status', '==', 'pending')
-    .where('dateTime', '>=', targetStart)
-    .where('dateTime', '<=', targetEnd)
+    .collection("appointments")
+    .where("status", "==", "pending")
+    .where("dateTime", ">=", targetStart)
+    .where("dateTime", "<=", targetEnd)
     .get();
 
   for (const docSnap of snap.docs) {
@@ -50,8 +73,8 @@ async function processReminders(minutesBefore: number, flag: string) {
 }
 
 export const scheduleAppointmentReminder = functions.pubsub
-  .schedule('* * * * *')
+  .schedule("* * * * *")
   .onRun(async () => {
-    await processReminders(MINUTES_BEFORE_24H, 'reminder24hSent');
-    await processReminders(MINUTES_BEFORE_30M, 'reminder30mSent');
+    await processReminders(MINUTES_BEFORE_24H, "reminder24hSent");
+    await processReminders(MINUTES_BEFORE_30M, "reminder30mSent");
   });

--- a/functions/scheduleAssessmentReminder.ts
+++ b/functions/scheduleAssessmentReminder.ts
@@ -1,18 +1,22 @@
-import * as functions from 'firebase-functions';
-import * as admin from 'firebase-admin';
-import sgMail from '@sendgrid/mail';
-import twilio from 'twilio';
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import sgMail from "@sendgrid/mail";
+import twilio from "twilio";
+import { isValidEmail, isValidE164 } from "./src/validators";
 
 admin.initializeApp();
 const db = admin.firestore();
 
 sgMail.setApiKey(process.env.SENDGRID_API_KEY as string);
-const twilioClient = twilio(process.env.TWILIO_SID as string, process.env.TWILIO_AUTH_TOKEN as string);
+const twilioClient = twilio(
+  process.env.TWILIO_SID as string,
+  process.env.TWILIO_AUTH_TOKEN as string,
+);
 
 const SENDGRID_FROM = process.env.SENDGRID_FROM_EMAIL as string;
 const TWILIO_SMS_FROM = process.env.TWILIO_SMS_FROM;
 
-const HOURS_AFTER = parseInt(process.env.ASSESSMENT_REMINDER_HOURS || '24');
+const HOURS_AFTER = parseInt(process.env.ASSESSMENT_REMINDER_HOURS || "24");
 
 async function notify(patientId: string, message: string) {
   const snap = await db.doc(`patients/${patientId}`).get();
@@ -20,27 +24,49 @@ async function notify(patientId: string, message: string) {
   if (!patient) return;
   const contact = patient.contact;
   if (contact) {
-    if (contact.includes('@')) {
-      await sgMail.send({ to: contact, from: SENDGRID_FROM, subject: 'Lembrete de Inventário', text: message });
+    if (contact.includes("@")) {
+      if (isValidEmail(contact)) {
+        await sgMail.send({
+          to: contact,
+          from: SENDGRID_FROM,
+          subject: "Lembrete de Inventário",
+          text: message,
+        });
+      } else {
+        console.error("Contato de email inválido", contact);
+      }
     } else if (TWILIO_SMS_FROM) {
-      await twilioClient.messages.create({ from: TWILIO_SMS_FROM, to: contact, body: message });
+      if (isValidE164(contact)) {
+        await twilioClient.messages.create({
+          from: TWILIO_SMS_FROM,
+          to: contact,
+          body: message,
+        });
+      } else {
+        console.error("Contato de telefone inválido", contact);
+      }
     }
   }
 }
 
 export const scheduleAssessmentReminder = functions.pubsub
-  .schedule('every 60 minutes')
+  .schedule("every 60 minutes")
   .onRun(async () => {
-    const cutoff = admin.firestore.Timestamp.fromMillis(Date.now() - HOURS_AFTER * 60 * 60 * 1000);
+    const cutoff = admin.firestore.Timestamp.fromMillis(
+      Date.now() - HOURS_AFTER * 60 * 60 * 1000,
+    );
     const snap = await db
-      .collectionGroup('assessments')
-      .where('status', '==', 'pending')
-      .where('createdAt', '<=', cutoff)
+      .collectionGroup("assessments")
+      .where("status", "==", "pending")
+      .where("createdAt", "<=", cutoff)
       .get();
 
     for (const docSnap of snap.docs) {
       const patientId = docSnap.ref.parent.parent?.id;
       if (!patientId) continue;
-      await notify(patientId, 'Você possui um inventário pendente para preenchimento.');
+      await notify(
+        patientId,
+        "Você possui um inventário pendente para preenchimento.",
+      );
     }
   });

--- a/functions/scheduleTaskReminder.ts
+++ b/functions/scheduleTaskReminder.ts
@@ -1,59 +1,71 @@
-import * as functions from 'firebase-functions';
-import * as admin from 'firebase-admin';
-import sgMail from '@sendgrid/mail';
-import twilio from 'twilio';
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import sgMail from "@sendgrid/mail";
+import twilio from "twilio";
+import { isValidEmail, isValidE164 } from "./src/validators";
 
 admin.initializeApp();
 const db = admin.firestore();
 
 sgMail.setApiKey(process.env.SENDGRID_API_KEY as string);
-const twilioClient = twilio(process.env.TWILIO_SID as string, process.env.TWILIO_AUTH_TOKEN as string);
+const twilioClient = twilio(
+  process.env.TWILIO_SID as string,
+  process.env.TWILIO_AUTH_TOKEN as string,
+);
 const SENDGRID_FROM = process.env.SENDGRID_FROM_EMAIL as string;
 const TWILIO_SMS_FROM = process.env.TWILIO_SMS_FROM;
 
-const MINUTES_BEFORE = parseInt(process.env.TASK_REMINDER_MINUTES || '10');
+const MINUTES_BEFORE = parseInt(process.env.TASK_REMINDER_MINUTES || "10");
 
 async function send(uid: string, taskId: string, title: string) {
   await admin.messaging().send({
     topic: uid,
-    notification: { title: 'Tarefa próxima', body: title },
+    notification: { title: "Tarefa próxima", body: title },
     data: { taskId },
   });
 
   try {
     const user = await admin.auth().getUser(uid);
     if (user.email) {
-      await sgMail.send({
-        to: user.email,
-        from: SENDGRID_FROM,
-        subject: 'Lembrete de Tarefa',
-        text: `Você possui a tarefa "${title}" com vencimento em breve.`,
-      });
+      if (isValidEmail(user.email)) {
+        await sgMail.send({
+          to: user.email,
+          from: SENDGRID_FROM,
+          subject: "Lembrete de Tarefa",
+          text: `Você possui a tarefa "${title}" com vencimento em breve.`,
+        });
+      } else {
+        console.error("Contato de email inválido", user.email);
+      }
     }
     if (user.phoneNumber && TWILIO_SMS_FROM) {
-      await twilioClient.messages.create({
-        from: TWILIO_SMS_FROM,
-        to: user.phoneNumber,
-        body: `Tarefa pendente: ${title}`,
-      });
+      if (isValidE164(user.phoneNumber)) {
+        await twilioClient.messages.create({
+          from: TWILIO_SMS_FROM,
+          to: user.phoneNumber,
+          body: `Tarefa pendente: ${title}`,
+        });
+      } else {
+        console.error("Contato de telefone inválido", user.phoneNumber);
+      }
     }
   } catch (e) {
-    console.error('Erro ao enviar email/SMS', e);
+    console.error("Erro ao enviar email/SMS", e);
   }
 }
 
 export const scheduleTaskReminder = functions.pubsub
-  .schedule('* * * * *')
+  .schedule("* * * * *")
   .onRun(async () => {
     const now = admin.firestore.Timestamp.now();
     const limit = admin.firestore.Timestamp.fromMillis(
       now.toMillis() + MINUTES_BEFORE * 60 * 1000,
     );
     const snap = await db
-      .collection('tasks')
-      .where('status', '==', 'pending')
-      .where('dueDate', '<=', limit)
-      .where('dueDate', '>', now)
+      .collection("tasks")
+      .where("status", "==", "pending")
+      .where("dueDate", "<=", limit)
+      .where("dueDate", ">", now)
       .get();
 
     for (const docSnap of snap.docs) {

--- a/functions/sendAssessmentLink.ts
+++ b/functions/sendAssessmentLink.ts
@@ -1,57 +1,89 @@
-import * as functions from 'firebase-functions';
-import * as admin from 'firebase-admin';
-import sgMail from '@sendgrid/mail';
-import twilio from 'twilio';
-import jwt from 'jsonwebtoken';
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import sgMail from "@sendgrid/mail";
+import twilio from "twilio";
+import jwt from "jsonwebtoken";
+import { isValidEmail, isValidE164 } from "./src/validators";
 
 admin.initializeApp();
 const db = admin.firestore();
 
 sgMail.setApiKey(process.env.SENDGRID_API_KEY as string);
-const twilioClient = twilio(process.env.TWILIO_SID as string, process.env.TWILIO_AUTH_TOKEN as string);
+const twilioClient = twilio(
+  process.env.TWILIO_SID as string,
+  process.env.TWILIO_AUTH_TOKEN as string,
+);
 const TOKEN_SECRET = process.env.ASSESSMENT_TOKEN_SECRET;
 if (!TOKEN_SECRET) {
-  throw new Error('ASSESSMENT_TOKEN_SECRET environment variable is required');
+  throw new Error("ASSESSMENT_TOKEN_SECRET environment variable is required");
 }
 
 function signToken(data: { patientId: string; assessmentId: string }) {
-  return jwt.sign(data, TOKEN_SECRET, { expiresIn: '7d' });
+  return jwt.sign(data, TOKEN_SECRET, { expiresIn: "7d" });
 }
 
-async function internalSend(patientId: string, assessmentId: string, channels: string[]) {
+async function internalSend(
+  patientId: string,
+  assessmentId: string,
+  channels: string[],
+) {
   const token = signToken({ patientId, assessmentId });
   const link = `${process.env.PUBLIC_URL}/assessments/fill/${token}`;
-  await db.doc(`patients/${patientId}/assessments/${assessmentId}`).update({ linkToken: token });
+  await db
+    .doc(`patients/${patientId}/assessments/${assessmentId}`)
+    .update({ linkToken: token });
   const patientSnap = await db.doc(`patients/${patientId}`).get();
   const patient = patientSnap.data();
   if (!patient) return;
 
-  if (channels.includes('email')) {
-    await sgMail.send({
-      to: patient.contact,
-      from: process.env.SENDGRID_FROM_EMAIL as string,
-      subject: 'Novo Inventário',
-      text: `Por favor, preencha: ${link}`,
-    });
+  if (channels.includes("email")) {
+    if (isValidEmail(patient.contact)) {
+      await sgMail.send({
+        to: patient.contact,
+        from: process.env.SENDGRID_FROM_EMAIL as string,
+        subject: "Novo Inventário",
+        text: `Por favor, preencha: ${link}`,
+      });
+    } else {
+      console.error("Contato de email inválido", patient.contact);
+    }
   }
 
-  if (channels.includes('whatsapp') && process.env.TWILIO_WHATSAPP_FROM) {
-    await twilioClient.messages.create({
-      from: process.env.TWILIO_WHATSAPP_FROM,
-      to: `whatsapp:${patient.contact}`,
-      body: `Preencha: ${link}`,
-    });
+  if (channels.includes("whatsapp") && process.env.TWILIO_WHATSAPP_FROM) {
+    if (isValidE164(patient.contact)) {
+      await twilioClient.messages.create({
+        from: process.env.TWILIO_WHATSAPP_FROM,
+        to: `whatsapp:${patient.contact}`,
+        body: `Preencha: ${link}`,
+      });
+    } else {
+      console.error("Contato de telefone inválido", patient.contact);
+    }
   }
 }
 
-export const sendAssessmentLink = functions.https.onCall(async (data: { patientId: string; assessmentId: string; channels: string[] }) => {
-  const { patientId, assessmentId, channels } = data;
-  await internalSend(patientId, assessmentId, channels);
-});
+export const sendAssessmentLink = functions.https.onCall(
+  async (data: {
+    patientId: string;
+    assessmentId: string;
+    channels: string[];
+  }) => {
+    const { patientId, assessmentId, channels } = data;
+    await internalSend(patientId, assessmentId, channels);
+  },
+);
 
 export const onAssessmentCreate = functions.firestore
-  .document('patients/{patientId}/assessments/{assessmentId}')
-  .onCreate(async (_snap: functions.firestore.DocumentSnapshot, ctx: functions.EventContext) => {
-    const { patientId, assessmentId } = ctx.params as { patientId: string; assessmentId: string };
-    await internalSend(patientId, assessmentId, ['email']);
-  });
+  .document("patients/{patientId}/assessments/{assessmentId}")
+  .onCreate(
+    async (
+      _snap: functions.firestore.DocumentSnapshot,
+      ctx: functions.EventContext,
+    ) => {
+      const { patientId, assessmentId } = ctx.params as {
+        patientId: string;
+        assessmentId: string;
+      };
+      await internalSend(patientId, assessmentId, ["email"]);
+    },
+  );

--- a/functions/src/validators.ts
+++ b/functions/src/validators.ts
@@ -1,0 +1,7 @@
+export function isValidEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+export function isValidE164(phone: string): boolean {
+  return /^\+[1-9]\d{1,14}$/.test(phone);
+}

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 import { format, addDays } from "date-fns";
 import type {
   Patient,

--- a/tests/patientCrypto.test.ts
+++ b/tests/patientCrypto.test.ts
@@ -1,8 +1,12 @@
-import { encryptPatient, decryptPatient, decryptPatientForRole } from '../src/lib/patientCrypto';
-import { Patient } from '../src/lib/types';
+import {
+  encryptPatient,
+  decryptPatient,
+  decryptPatientForRole,
+} from "../src/lib/patientCrypto";
+import { Patient } from "../src/lib/types";
 
 beforeAll(() => {
-  const key = Buffer.alloc(32).toString('base64');
+  const key = Buffer.alloc(32).toString("base64");
   process.env.CRYPTO_SECRET_KEY = key;
 });
 
@@ -11,34 +15,56 @@ afterAll(() => {
 });
 
 const patient: Patient = {
-  id: 'p1',
-  name: 'Test',
-  contact: '1234567890',
-  cpf: '11122233344',
-  dateOfBirth: '2000-01-01',
+  id: "p1",
+  name: "Test",
+  contact: "1234567890",
+  cpf: "11122233344",
+  dateOfBirth: "2000-01-01",
   sessionNotes: [
     {
-      id: 'n1',
-      date: '2024-01-01',
-      notes: 'ok',
-      sessionSummary: 'ok',
-      sessionTags: ['teste'],
+      id: "n1",
+      date: "2024-01-01",
+      notes: "ok",
+      sessionSummary: "ok",
+      sessionTags: ["teste"],
     },
   ],
-  treatmentPlan: 'Plano inicial',
+  treatmentPlan: "Plano inicial",
 };
 
-test('encryptPatient/decryptPatient roundtrip', () => {
+const patientNoOptional: Patient = {
+  id: "p2",
+  name: "NoOpt",
+  contact: "000",
+  dateOfBirth: "2000-01-01",
+  sessionNotes: [
+    {
+      id: "n1",
+      date: "2024-01-01",
+      notes: "hi",
+      sessionTags: [],
+    },
+  ],
+};
+
+test("encryptPatient/decryptPatient roundtrip", () => {
   const enc = encryptPatient(patient);
   expect(enc.name).not.toBe(patient.name);
   const dec = decryptPatient(enc);
   expect(dec).toEqual(patient);
 });
 
-test('decryptPatientForRole only decrypts for PSYCHOLOGIST', () => {
+test("decryptPatientForRole only decrypts for PSYCHOLOGIST", () => {
   const enc = encryptPatient(patient);
-  const asPsych = decryptPatientForRole(enc, 'PSYCHOLOGIST');
+  const asPsych = decryptPatientForRole(enc, "PSYCHOLOGIST");
   expect(asPsych).toEqual(patient);
-  const asOther = decryptPatientForRole(enc, 'RECEPCAO');
+  const asOther = decryptPatientForRole(enc, "RECEPCAO");
   expect(asOther.name).not.toBe(patient.name);
+});
+
+test("encryptPatient handles optional fields", () => {
+  const enc = encryptPatient(patientNoOptional);
+  expect(enc.cpf).toBeUndefined();
+  const dec = decryptPatient(enc);
+  expect(dec).toEqual(patientNoOptional);
 });

--- a/tests/timeline.test.ts
+++ b/tests/timeline.test.ts
@@ -1,16 +1,22 @@
-process.env.CRYPTO_SECRET_KEY = Buffer.alloc(32).toString('base64');
-import { generateTimelineEvents } from '../src/lib/timeline';
-import { mockAppointments, getMockPatientsList } from '../src/lib/mock-data';
+process.env.CRYPTO_SECRET_KEY = Buffer.alloc(32).toString("base64");
+import { generateTimelineEvents } from "../src/lib/timeline";
+import { mockAppointments, getMockPatientsList } from "../src/lib/mock-data";
 
-test('generateTimelineEvents merges and sorts events', () => {
+test("generateTimelineEvents merges and sorts events", () => {
   const events = generateTimelineEvents();
   const patients = getMockPatientsList();
   expect(events.length).toBe(
-    mockAppointments.length + patients.reduce((sum, p) => sum + p.sessionNotes.length, 0)
+    mockAppointments.length +
+      patients.reduce((sum, p) => sum + p.sessionNotes.length, 0),
   );
   for (let i = 1; i < events.length; i++) {
     const prev = new Date(events[i - 1].date).getTime();
     const curr = new Date(events[i].date).getTime();
     expect(prev).toBeLessThanOrEqual(curr);
   }
+});
+
+test("generateTimelineEvents filters by patientId", () => {
+  const events = generateTimelineEvents("patient-001");
+  expect(events.length).toBe(4);
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,7 +1,7 @@
-import { encrypt, decrypt } from '../src/lib/utils';
+import { encrypt, decrypt, formatCPF, isValidCPF } from "../src/lib/utils";
 
 beforeAll(() => {
-  const key = Buffer.alloc(32).toString('base64');
+  const key = Buffer.alloc(32).toString("base64");
   process.env.CRYPTO_SECRET_KEY = key;
 });
 
@@ -9,17 +9,58 @@ afterAll(() => {
   delete process.env.CRYPTO_SECRET_KEY;
 });
 
-describe('encrypt/decrypt', () => {
-  const plaintext = 'hello world';
+describe("encrypt/decrypt", () => {
+  const plaintext = "hello world";
 
-  it('encrypt produces output different from the plaintext', () => {
+  it("encrypt produces output different from the plaintext", () => {
     const cipher = encrypt(plaintext);
     expect(cipher).not.toBe(plaintext);
   });
 
-  it('decrypt(encrypt(text)) returns the original plaintext', () => {
+  it("decrypt(encrypt(text)) returns the original plaintext", () => {
     const cipher = encrypt(plaintext);
     const decrypted = decrypt(cipher);
     expect(decrypted).toBe(plaintext);
   });
+});
+
+describe("formatCPF/isValidCPF", () => {
+  it("formats CPF correctly", () => {
+    expect(formatCPF("52998224725")).toBe("529.982.247-25");
+  });
+
+  it("validates CPF", () => {
+    expect(isValidCPF("529.982.247-25")).toBe(true);
+    expect(isValidCPF("111.111.111-11")).toBe(false);
+  });
+});
+
+describe("getCryptoKey", () => {
+  it("throws if key not set and not in development", () => {
+    delete process.env.CRYPTO_SECRET_KEY;
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = "test";
+    jest.resetModules();
+    const { getCryptoKey } = require("../src/lib/utils");
+    expect(() => getCryptoKey()).toThrow("CRYPTO_SECRET_KEY is not set");
+    process.env.NODE_ENV = prev;
+    process.env.CRYPTO_SECRET_KEY = Buffer.alloc(32).toString("base64");
+  });
+
+  it("generates random key in development", () => {
+    delete process.env.CRYPTO_SECRET_KEY;
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = "development";
+    jest.resetModules();
+    const { getCryptoKey } = require("../src/lib/utils");
+    const key = getCryptoKey();
+    expect(Buffer.isBuffer(key)).toBe(true);
+    process.env.NODE_ENV = prev;
+    process.env.CRYPTO_SECRET_KEY = Buffer.alloc(32).toString("base64");
+  });
+});
+
+test("cn merges class names", () => {
+  const { cn } = require("../src/lib/utils");
+  expect(cn("a", false && "b", "c")).toBe("a c");
 });

--- a/tests/validators.test.ts
+++ b/tests/validators.test.ts
@@ -1,0 +1,13 @@
+import { isValidEmail, isValidE164 } from "../functions/src/validators";
+
+describe("validators", () => {
+  test("isValidEmail validates correctly", () => {
+    expect(isValidEmail("test@example.com")).toBe(true);
+    expect(isValidEmail("invalid")).toBe(false);
+  });
+
+  test("isValidE164 validates correctly", () => {
+    expect(isValidE164("+1234567890")).toBe(true);
+    expect(isValidE164("12345")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add email & phone validation utilities
- validate contact info in assessment and reminder functions
- skip mock-data from coverage
- test validators and improve utils & crypto tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843d16b6c9c8324b45902cef8d41a45