### PR TITLE
Add configurable token expiry

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -12,6 +12,8 @@ FIREBASE_SERVICE_ACCOUNT=<service_account_json>
 
 # JWT secret used for assessment links
 ASSESSMENT_TOKEN_SECRET=replace_me_secret
+# Expiration for assessment links (e.g. 7d)
+ASSESSMENT_TOKEN_EXPIRY=7d
 
 # SendGrid configuration
 SENDGRID_API_KEY=your_sendgrid_key
@@ -30,4 +32,4 @@ TASK_REMINDER_MINUTES=
 ASSESSMENT_REMINDER_HOURS=
 
 # Public URL used in assessment links
-PUBLIC_URL=http://localhost:3000
+PUBLIC_URL=https://localhost:3000

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ CRYPTO_SECRET_KEY=REPLACE_ME_BASE64_32BYTES
 | `CRYPTO_SECRET_KEY` | Chave AES para criptografar dados sensíveis | não |
 | `FIREBASE_SERVICE_ACCOUNT` | JSON da conta de serviço para o Admin SDK | não |
 | `ASSESSMENT_TOKEN_SECRET` | Segredo para assinar links de inventários | não |
+| `ASSESSMENT_TOKEN_EXPIRY` | Validade dos links de inventário (padrão 7d) | sim |
 | `SENDGRID_API_KEY` | Chave da API SendGrid para envio de e-mails | não |
 | `SENDGRID_FROM_EMAIL` | Endereço remetente usado pelo SendGrid | não |
 | `TWILIO_SID` | SID da conta Twilio | não |
@@ -45,7 +46,7 @@ CRYPTO_SECRET_KEY=REPLACE_ME_BASE64_32BYTES
 | `TWILIO_WHATSAPP_FROM` | Número de origem para WhatsApp | sim |
 | `TASK_REMINDER_MINUTES` | Minutos antes do vencimento para disparar lembrete de tarefa (padrão 10) | sim |
 | `ASSESSMENT_REMINDER_HOURS` | Horas após a criação para lembrar inventários pendentes (padrão 24) | sim |
-| `PUBLIC_URL` | URL pública usada nos links enviados por e-mail ou WhatsApp | não |
+| `PUBLIC_URL` | URL pública usada nos links (requer HTTPS) | não |
 
 Todos os dados de pacientes são criptografados no cliente usando AES antes de serem manipulados.
 

--- a/functions/sendAssessmentLink.ts
+++ b/functions/sendAssessmentLink.ts
@@ -13,14 +13,19 @@ const TOKEN_SECRET = process.env.ASSESSMENT_TOKEN_SECRET;
 if (!TOKEN_SECRET) {
   throw new Error('ASSESSMENT_TOKEN_SECRET environment variable is required');
 }
+const TOKEN_EXPIRY = process.env.ASSESSMENT_TOKEN_EXPIRY || '7d';
+const PUBLIC_URL = process.env.PUBLIC_URL as string;
+if (PUBLIC_URL && !PUBLIC_URL.startsWith('https://')) {
+  console.warn('PUBLIC_URL should use HTTPS');
+}
 
-function signToken(data: { patientId: string; assessmentId: string }) {
-  return jwt.sign(data, TOKEN_SECRET, { expiresIn: '7d' });
+export function signToken(data: { patientId: string; assessmentId: string }) {
+  return jwt.sign(data, TOKEN_SECRET, { expiresIn: TOKEN_EXPIRY });
 }
 
 async function internalSend(patientId: string, assessmentId: string, channels: string[]) {
   const token = signToken({ patientId, assessmentId });
-  const link = `${process.env.PUBLIC_URL}/assessments/fill/${token}`;
+  const link = `${PUBLIC_URL}/assessments/fill/${token}`;
   await db.doc(`patients/${patientId}/assessments/${assessmentId}`).update({ linkToken: token });
   const patientSnap = await db.doc(`patients/${patientId}`).get();
   const patient = patientSnap.data();

--- a/functions/src/sendAssessmentLink.ts
+++ b/functions/src/sendAssessmentLink.ts
@@ -11,14 +11,19 @@ const db = admin.firestore();
 sgMail.setApiKey(process.env.SENDGRID_API_KEY as string);
 const twilioClient = twilio(process.env.TWILIO_SID as string, process.env.TWILIO_AUTH_TOKEN as string);
 const TOKEN_SECRET = process.env.ASSESSMENT_TOKEN_SECRET as string;
+const TOKEN_EXPIRY = process.env.ASSESSMENT_TOKEN_EXPIRY || '7d';
+const PUBLIC_URL = process.env.PUBLIC_URL as string;
+if (PUBLIC_URL && !PUBLIC_URL.startsWith('https://')) {
+  console.warn('PUBLIC_URL should use HTTPS');
+}
 
-function signToken(data: { patientId: string; assessmentId: string }) {
-  return jwt.sign(data, TOKEN_SECRET, { expiresIn: '7d' });
+export function signToken(data: { patientId: string; assessmentId: string }) {
+  return jwt.sign(data, TOKEN_SECRET, { expiresIn: TOKEN_EXPIRY });
 }
 
 async function internalSend(patientId: string, assessmentId: string, channels: string[]) {
   const token = signToken({ patientId, assessmentId });
-  const link = `${process.env.PUBLIC_URL}/assessments/fill/${token}`;
+  const link = `${PUBLIC_URL}/assessments/fill/${token}`;
   await db.doc(`patients/${patientId}/assessments/${assessmentId}`).update({ linkToken: token });
   const patientSnap = await db.doc(`patients/${patientId}`).get();
   const patient = patientSnap.data();

--- a/tests/sendAssessmentLink.test.ts
+++ b/tests/sendAssessmentLink.test.ts
@@ -1,0 +1,25 @@
+process.env.ASSESSMENT_TOKEN_SECRET = 'secret';
+process.env.ASSESSMENT_TOKEN_EXPIRY = '1h';
+process.env.SENDGRID_API_KEY = 'SG.test';
+jest.mock('firebase-functions/v2/https', () => ({ onCall: (fn: any) => fn }));
+jest.mock('firebase-functions/v2/firestore', () => ({
+  onDocumentCreated: () => () => {},
+  onDocumentUpdated: () => () => {},
+}));
+import { signToken } from '../functions/src/sendAssessmentLink';
+import jwt from 'jsonwebtoken';
+
+
+afterAll(() => {
+  delete process.env.ASSESSMENT_TOKEN_SECRET;
+  delete process.env.ASSESSMENT_TOKEN_EXPIRY;
+  delete process.env.SENDGRID_API_KEY;
+});
+
+test('token expiration respects ASSESSMENT_TOKEN_EXPIRY', () => {
+  const token = signToken({ patientId: 'p1', assessmentId: 'a1' });
+  const payload = jwt.decode(token) as jwt.JwtPayload;
+  expect(payload && payload.exp && payload.iat).toBeDefined();
+  const diff = (payload!.exp! as number) - (payload!.iat! as number);
+  expect(diff).toBeLessThanOrEqual(3600);
+});


### PR DESCRIPTION
## Summary
- load ASSESSMENT_TOKEN_EXPIRY and PUBLIC_URL from env
- warn if PUBLIC_URL does not use HTTPS
- expose signToken for testing and update sendAssessmentLink
- document ASSESSMENT_TOKEN_EXPIRY and secure PUBLIC_URL
- add test for configurable assessment link expiry

## Testing
- `npm test` *(fails: global coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_6843d17a301c832483a10a9f4b08efbd