### PR TITLE
Fix CSP headers

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,16 @@
 import type {NextConfig} from 'next';
 
+const csp = [
+  "default-src 'self'",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "font-src 'self' https://fonts.gstatic.com",
+  "script-src 'self' 'unsafe-inline'",
+].join('; ') + ';';
+
 const securityHeaders = [
   {
     key: 'Content-Security-Policy',
-    value: "default-src 'self'"
+    value: csp,
   },
   {
     key: 'X-Content-Type-Options',


### PR DESCRIPTION
## Summary
- allow Google fonts and inline styles
- configure inline scripts in CSP header

## Testing
- `npm test` *(fails: coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_6843d5c780988324aadf29184ca3d0a6