### PR TITLE
Add troubleshooting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,13 @@ Para começar, abra `src/app/page.tsx` e siga a estrutura do App Router.
 
 ## Environment Variables
 
-Crie um arquivo **`.env.local`** na raiz do projeto com suas credenciais do Firebase.  
+Crie um arquivo **`.env.local`** na raiz do projeto com suas credenciais do Firebase.
+Você pode copiar o arquivo `\.env.local.example` e preenchê-lo com suas chaves:
+
+```bash
+cp .env.local.example .env.local
+```
+
 Use o template abaixo como guia:
 
 ```dotenv
@@ -49,6 +55,10 @@ CRYPTO_SECRET_KEY=REPLACE_ME_BASE64_32BYTES
 | `TASK_REMINDER_CRON` | Cron de execução do lembrete de tarefas (padrão `* * * * *`) | sim |
 | `ASSESSMENT_REMINDER_HOURS` | Horas após a criação para lembrar inventários pendentes (padrão 24) | sim |
 | `PUBLIC_URL` | URL pública usada nos links (requer HTTPS) | não |
+
+Se ocorrerem erros de login como "Could not reach Cloud Firestore backend" ou
+`auth/internal-error`, consulte [docs/troubleshooting.md](docs/troubleshooting.md)
+para passos de correção.
 
 Todos os dados de pacientes são criptografados no cliente usando AES antes de serem manipulados.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,19 @@
+# Solução de Problemas
+
+## Erro ao logar: "Could not reach Cloud Firestore backend" ou `auth/internal-error`
+
+Esses erros normalmente indicam que as variáveis de ambiente do Firebase não foram definidas ou que a conexão de rede está indisponível.
+
+### Passos para resolver
+
+1. Copie o arquivo `.env.local.example` para `.env.local`:
+   ```bash
+   cp .env.local.example .env.local
+   ```
+2. Preencha as chaves do Firebase e demais segredos no arquivo `.env.local`.
+3. Verifique se as variáveis `FIREBASE_SERVICE_ACCOUNT` e `ASSESSMENT_TOKEN_SECRET` também estão definidas.
+4. Garanta que sua máquina está conectada à internet ou, se preferir trabalhar offline, execute:
+   ```bash
+   firebase emulators:start
+   ```
+5. Reinicie o servidor de desenvolvimento (`npm run dev`).


### PR DESCRIPTION
## Summary
- add troubleshooting doc with step-by-step tasks
- mention example env file in README
- link to troubleshooting guide from README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843da7c394083248cbedd64961b09b0