### PR TITLE
Fix Firebase config env usage

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,7 @@ const csp = [
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
   "font-src 'self' https://fonts.gstatic.com",
   "script-src 'self' 'unsafe-inline'",
+  "connect-src 'self' https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://firebasestorage.googleapis.com",
 ].join('; ') + ';';
 
 const securityHeaders = [

--- a/src/lib/firebaseClient.ts
+++ b/src/lib/firebaseClient.ts
@@ -1,21 +1,63 @@
-import { initializeApp, getApps } from 'firebase/app';
-import { getFirestore } from 'firebase/firestore';
+import { FirebaseError, FirebaseApp, initializeApp, getApps } from 'firebase/app';
+import {
+  getFirestore,
+  enableNetwork,
+  disableNetwork,
+} from 'firebase/firestore';
 import { getAuth } from 'firebase/auth';
 import { getStorage } from 'firebase/storage';
 
-// Your web app's Firebase configuration
+// Firebase configuration loaded from environment variables
 const firebaseConfig = {
-  apiKey: 'AIzaSyCkp-Yp3CPOVl5jkmprh7BwP86Es-H9RzI',
-  authDomain: 'plataforma-bpsy.firebaseapp.com',
-  projectId: 'plataforma-bpsy',
-  storageBucket: 'plataforma-bpsy.firebasestorage.app',
-  messagingSenderId: '115174793204',
-  appId: '1:115174793204:web:dd38de43781c2ac5a423a1',
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
 };
 
-// Initialize Firebase
-const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+Object.entries(firebaseConfig).forEach(([key, value]) => {
+  if (!value) {
+    console.error(
+      `Firebase config missing for ${key}. Check your NEXT_PUBLIC_FIREBASE_* env vars.`
+    );
+  }
+});
+
+let app: FirebaseApp;
+try {
+  app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+} catch (err) {
+  const error = err as FirebaseError;
+  console.error('Firebase initialization error:', error.code || error.message);
+  throw err;
+}
 
 export const db = getFirestore(app);
 export const auth = getAuth(app);
 export const storage = getStorage(app);
+
+if (typeof window !== 'undefined') {
+  const updateNetwork = async () => {
+    if (navigator.onLine) {
+      try {
+        await enableNetwork(db);
+        console.info('Firebase network enabled');
+      } catch (err) {
+        console.error('Failed to enable Firebase network', err);
+      }
+    } else {
+      try {
+        await disableNetwork(db);
+        console.warn('Network unavailable, using offline Firestore');
+      } catch (err) {
+        console.error('Failed to disable Firebase network', err);
+      }
+    }
+  };
+
+  window.addEventListener('online', updateNetwork);
+  window.addEventListener('offline', updateNetwork);
+  updateNetwork();
+}


### PR DESCRIPTION
## Summary
- load firebase credentials from environment variables
- add offline detection in firebaseClient
- allow Firebase URLs in Content Security Policy

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: "No overload matches this call" etc.)*
- `npm test` *(fails: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_6843db164d1c8324b2b79ebf39a5e225