### PR TITLE
Use Firebase config for secrets

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,25 +1,26 @@
-NEXT_PUBLIC_FIREBASE_API_KEY=your_api_key
-NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your_project.firebaseapp.com
-NEXT_PUBLIC_FIREBASE_PROJECT_ID=your_project_id
-NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your_project.appspot.com
-NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
-NEXT_PUBLIC_FIREBASE_APP_ID=your_app_id
+# Valores do Firebase
+NEXT_PUBLIC_FIREBASE_API_KEY=
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=
+NEXT_PUBLIC_FIREBASE_APP_ID=
 # Não use esta chave em produção!
-CRYPTO_SECRET_KEY=REPLACE_ME_BASE64_32BYTES
+CRYPTO_SECRET_KEY=
 
 # Service account JSON string for Firebase Admin SDK
-FIREBASE_SERVICE_ACCOUNT=<service_account_json>
+FIREBASE_SERVICE_ACCOUNT=
 
 # JWT secret used for assessment links
-ASSESSMENT_TOKEN_SECRET=replace_me_secret
+ASSESSMENT_TOKEN_SECRET=
 
 # SendGrid configuration
-SENDGRID_API_KEY=your_sendgrid_key
-SENDGRID_FROM_EMAIL=no-reply@example.com
+SENDGRID_API_KEY=
+SENDGRID_FROM_EMAIL=
 
 # Twilio configuration
-TWILIO_SID=your_twilio_sid
-TWILIO_AUTH_TOKEN=your_twilio_auth_token
+TWILIO_SID=
+TWILIO_AUTH_TOKEN=
 
 # Optional numbers for SMS/WhatsApp notifications
 TWILIO_SMS_FROM=

--- a/docs/env.md
+++ b/docs/env.md
@@ -6,8 +6,27 @@ Para gerar uma chave segura para `CRYPTO_SECRET_KEY` execute:
 openssl rand -base64 32
 ```
 
-Configure essa chave em `.env.local` durante o desenvolvimento e também nas funções do Firebase:
+Configure essa chave em `.env.local` durante o desenvolvimento e também registre-a como segredo nas funções do Firebase:
 
 ```bash
 firebase functions:config:set secrets.crypto_key="<SUA_CHAVE>"
+
+# Segredos adicionais
+
+Defina outros valores sensíveis, como chaves da SendGrid ou credenciais do Twilio,
+utilizando o mesmo comando. Por exemplo:
+
+```bash
+firebase functions:config:set \
+  secrets.sendgrid_api_key="<SENDGRID_KEY>" \
+  secrets.sendgrid_from_email="no-reply@example.com" \
+  secrets.twilio_sid="<TWILIO_SID>" \
+  secrets.twilio_auth_token="<TWILIO_TOKEN>"
+```
+
+Para usar estes valores localmente no emulador exporte a configuração para
+`.runtimeconfig.json`:
+
+```bash
+firebase functions:config:get > .runtimeconfig.json
 ```

--- a/functions/scheduleAppointmentReminder.ts
+++ b/functions/scheduleAppointmentReminder.ts
@@ -6,11 +6,15 @@ import twilio from 'twilio';
 admin.initializeApp();
 const db = admin.firestore();
 
-sgMail.setApiKey(process.env.SENDGRID_API_KEY as string);
-const twilioClient = twilio(process.env.TWILIO_SID as string, process.env.TWILIO_AUTH_TOKEN as string);
+const secrets = functions.config().secrets || {};
+sgMail.setApiKey(secrets.sendgrid_api_key || (process.env.SENDGRID_API_KEY as string));
+const twilioClient = twilio(
+  secrets.twilio_sid || (process.env.TWILIO_SID as string),
+  secrets.twilio_auth_token || (process.env.TWILIO_AUTH_TOKEN as string),
+);
 
-const SENDGRID_FROM = process.env.SENDGRID_FROM_EMAIL as string;
-const TWILIO_SMS_FROM = process.env.TWILIO_SMS_FROM;
+const SENDGRID_FROM = secrets.sendgrid_from_email || (process.env.SENDGRID_FROM_EMAIL as string);
+const TWILIO_SMS_FROM = secrets.twilio_sms_from || process.env.TWILIO_SMS_FROM;
 
 const MINUTES_BEFORE_24H = 24 * 60; // 24 hours
 const MINUTES_BEFORE_30M = 30; // 30 minutes

--- a/functions/scheduleAssessmentReminder.ts
+++ b/functions/scheduleAssessmentReminder.ts
@@ -6,13 +6,17 @@ import twilio from 'twilio';
 admin.initializeApp();
 const db = admin.firestore();
 
-sgMail.setApiKey(process.env.SENDGRID_API_KEY as string);
-const twilioClient = twilio(process.env.TWILIO_SID as string, process.env.TWILIO_AUTH_TOKEN as string);
+const secrets = functions.config().secrets || {};
+sgMail.setApiKey(secrets.sendgrid_api_key || (process.env.SENDGRID_API_KEY as string));
+const twilioClient = twilio(
+  secrets.twilio_sid || (process.env.TWILIO_SID as string),
+  secrets.twilio_auth_token || (process.env.TWILIO_AUTH_TOKEN as string),
+);
 
-const SENDGRID_FROM = process.env.SENDGRID_FROM_EMAIL as string;
-const TWILIO_SMS_FROM = process.env.TWILIO_SMS_FROM;
+const SENDGRID_FROM = secrets.sendgrid_from_email || (process.env.SENDGRID_FROM_EMAIL as string);
+const TWILIO_SMS_FROM = secrets.twilio_sms_from || process.env.TWILIO_SMS_FROM;
 
-const HOURS_AFTER = parseInt(process.env.ASSESSMENT_REMINDER_HOURS || '24');
+const HOURS_AFTER = parseInt(secrets.assessment_reminder_hours || process.env.ASSESSMENT_REMINDER_HOURS || '24');
 
 async function notify(patientId: string, message: string) {
   const snap = await db.doc(`patients/${patientId}`).get();

--- a/functions/scheduleTaskReminder.ts
+++ b/functions/scheduleTaskReminder.ts
@@ -6,12 +6,16 @@ import twilio from 'twilio';
 admin.initializeApp();
 const db = admin.firestore();
 
-sgMail.setApiKey(process.env.SENDGRID_API_KEY as string);
-const twilioClient = twilio(process.env.TWILIO_SID as string, process.env.TWILIO_AUTH_TOKEN as string);
-const SENDGRID_FROM = process.env.SENDGRID_FROM_EMAIL as string;
-const TWILIO_SMS_FROM = process.env.TWILIO_SMS_FROM;
+const secrets = functions.config().secrets || {};
+sgMail.setApiKey(secrets.sendgrid_api_key || (process.env.SENDGRID_API_KEY as string));
+const twilioClient = twilio(
+  secrets.twilio_sid || (process.env.TWILIO_SID as string),
+  secrets.twilio_auth_token || (process.env.TWILIO_AUTH_TOKEN as string),
+);
+const SENDGRID_FROM = secrets.sendgrid_from_email || (process.env.SENDGRID_FROM_EMAIL as string);
+const TWILIO_SMS_FROM = secrets.twilio_sms_from || process.env.TWILIO_SMS_FROM;
 
-const MINUTES_BEFORE = parseInt(process.env.TASK_REMINDER_MINUTES || '10');
+const MINUTES_BEFORE = parseInt(secrets.task_reminder_minutes || process.env.TASK_REMINDER_MINUTES || '10');
 
 async function send(uid: string, taskId: string, title: string) {
   await admin.messaging().send({

--- a/functions/sendAssessmentLink.ts
+++ b/functions/sendAssessmentLink.ts
@@ -7,9 +7,16 @@ import jwt from 'jsonwebtoken';
 admin.initializeApp();
 const db = admin.firestore();
 
-sgMail.setApiKey(process.env.SENDGRID_API_KEY as string);
-const twilioClient = twilio(process.env.TWILIO_SID as string, process.env.TWILIO_AUTH_TOKEN as string);
-const TOKEN_SECRET = process.env.ASSESSMENT_TOKEN_SECRET;
+const secrets = functions.config().secrets || {};
+sgMail.setApiKey(secrets.sendgrid_api_key || (process.env.SENDGRID_API_KEY as string));
+const twilioClient = twilio(
+  secrets.twilio_sid || (process.env.TWILIO_SID as string),
+  secrets.twilio_auth_token || (process.env.TWILIO_AUTH_TOKEN as string),
+);
+const TOKEN_SECRET = secrets.assessment_token_secret || process.env.ASSESSMENT_TOKEN_SECRET;
+const FROM_EMAIL = secrets.sendgrid_from_email || process.env.SENDGRID_FROM_EMAIL;
+const WHATSAPP_FROM = secrets.twilio_whatsapp_from || process.env.TWILIO_WHATSAPP_FROM;
+const PUBLIC_URL = secrets.public_url || process.env.PUBLIC_URL;
 if (!TOKEN_SECRET) {
   throw new Error('ASSESSMENT_TOKEN_SECRET environment variable is required');
 }
@@ -20,7 +27,7 @@ function signToken(data: { patientId: string; assessmentId: string }) {
 
 async function internalSend(patientId: string, assessmentId: string, channels: string[]) {
   const token = signToken({ patientId, assessmentId });
-  const link = `${process.env.PUBLIC_URL}/assessments/fill/${token}`;
+  const link = `${PUBLIC_URL}/assessments/fill/${token}`;
   await db.doc(`patients/${patientId}/assessments/${assessmentId}`).update({ linkToken: token });
   const patientSnap = await db.doc(`patients/${patientId}`).get();
   const patient = patientSnap.data();
@@ -29,15 +36,15 @@ async function internalSend(patientId: string, assessmentId: string, channels: s
   if (channels.includes('email')) {
     await sgMail.send({
       to: patient.contact,
-      from: process.env.SENDGRID_FROM_EMAIL as string,
+      from: FROM_EMAIL as string,
       subject: 'Novo Inventário',
       text: `Por favor, preencha: ${link}`,
     });
   }
 
-  if (channels.includes('whatsapp') && process.env.TWILIO_WHATSAPP_FROM) {
+  if (channels.includes('whatsapp') && WHATSAPP_FROM) {
     await twilioClient.messages.create({
-      from: process.env.TWILIO_WHATSAPP_FROM,
+      from: WHATSAPP_FROM,
       to: `whatsapp:${patient.contact}`,
       body: `Preencha: ${link}`,
     });

--- a/functions/src/sendAssessmentLink.ts
+++ b/functions/src/sendAssessmentLink.ts
@@ -1,6 +1,7 @@
 import * as admin from 'firebase-admin';
 import { onDocumentCreated, onDocumentUpdated } from 'firebase-functions/v2/firestore';
 import { onCall, CallableRequest } from 'firebase-functions/v2/https';
+import * as functions from 'firebase-functions';
 import sgMail from '@sendgrid/mail';
 import twilio from 'twilio';
 import jwt from 'jsonwebtoken';
@@ -8,9 +9,16 @@ import jwt from 'jsonwebtoken';
 admin.initializeApp();
 const db = admin.firestore();
 
-sgMail.setApiKey(process.env.SENDGRID_API_KEY as string);
-const twilioClient = twilio(process.env.TWILIO_SID as string, process.env.TWILIO_AUTH_TOKEN as string);
-const TOKEN_SECRET = process.env.ASSESSMENT_TOKEN_SECRET as string;
+const secrets = functions.config().secrets || {};
+sgMail.setApiKey(secrets.sendgrid_api_key || (process.env.SENDGRID_API_KEY as string));
+const twilioClient = twilio(
+  secrets.twilio_sid || (process.env.TWILIO_SID as string),
+  secrets.twilio_auth_token || (process.env.TWILIO_AUTH_TOKEN as string),
+);
+const TOKEN_SECRET = (secrets.assessment_token_secret || process.env.ASSESSMENT_TOKEN_SECRET) as string;
+const FROM_EMAIL = secrets.sendgrid_from_email || process.env.SENDGRID_FROM_EMAIL;
+const WHATSAPP_FROM = secrets.twilio_whatsapp_from || process.env.TWILIO_WHATSAPP_FROM;
+const PUBLIC_URL = secrets.public_url || process.env.PUBLIC_URL;
 
 function signToken(data: { patientId: string; assessmentId: string }) {
   return jwt.sign(data, TOKEN_SECRET, { expiresIn: '7d' });
@@ -18,7 +26,7 @@ function signToken(data: { patientId: string; assessmentId: string }) {
 
 async function internalSend(patientId: string, assessmentId: string, channels: string[]) {
   const token = signToken({ patientId, assessmentId });
-  const link = `${process.env.PUBLIC_URL}/assessments/fill/${token}`;
+  const link = `${PUBLIC_URL}/assessments/fill/${token}`;
   await db.doc(`patients/${patientId}/assessments/${assessmentId}`).update({ linkToken: token });
   const patientSnap = await db.doc(`patients/${patientId}`).get();
   const patient = patientSnap.data();
@@ -27,15 +35,15 @@ async function internalSend(patientId: string, assessmentId: string, channels: s
   if (channels.includes('email')) {
     await sgMail.send({
       to: patient.contact,
-      from: process.env.SENDGRID_FROM_EMAIL as string,
+      from: FROM_EMAIL as string,
       subject: 'Novo Inventário',
       text: `Por favor, preencha: ${link}`,
     });
   }
 
-  if (channels.includes('whatsapp') && process.env.TWILIO_WHATSAPP_FROM) {
+  if (channels.includes('whatsapp') && WHATSAPP_FROM) {
     await twilioClient.messages.create({
-      from: process.env.TWILIO_WHATSAPP_FROM,
+      from: WHATSAPP_FROM,
       to: `whatsapp:${patient.contact}`,
       body: `Preencha: ${link}`,
     });


### PR DESCRIPTION
## Summary
- update example environment file to remove sensitive placeholders
- explain how to set secrets with `firebase functions:config:set`
- read secrets from `functions.config()` in Cloud Functions

## Testing
- `npm test` *(fails: jest not found)*
- `npm --prefix functions run build`
- `firebase functions:config:get > .runtimeconfig.json` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843d17536648324ae8a8f6953246662