### PR TITLE
Add SESSION_VALIDATION_MS env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ CRYPTO_SECRET_KEY=REPLACE_ME_BASE64_32BYTES
 | `APPOINTMENT_REMINDER_CRON` | Cron de execução do lembrete de sessões (padrão `* * * * *`) | sim |
 | `TASK_REMINDER_CRON` | Cron de execução do lembrete de tarefas (padrão `* * * * *`) | sim |
 | `ASSESSMENT_REMINDER_HOURS` | Horas após a criação para lembrar inventários pendentes (padrão 24) | sim |
+| `SESSION_VALIDATION_MS` | Intervalo em ms para validar a sessão do usuário (padrão 60000) | sim |
 | `PUBLIC_URL` | URL pública usada nos links (requer HTTPS) | não |
 
 Se ocorrerem erros de login como "Could not reach Cloud Firestore backend" ou

--- a/docs/env.md
+++ b/docs/env.md
@@ -24,3 +24,4 @@ NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=plataforma-bpsy.firebasestorage.app
 NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=115174793204
 NEXT_PUBLIC_FIREBASE_APP_ID=1:115174793204:web:dd38de43781c2ac5a423a1
 ```
+- `SESSION_VALIDATION_MS`: intervalo em milissegundos para validar a sessão do usuário (padrão 60000).

--- a/src/hooks/useSessionValidation.ts
+++ b/src/hooks/useSessionValidation.ts
@@ -5,10 +5,16 @@ import { db } from "@/lib/firebaseClient";
 import type { User } from "@/lib/types";
 
 const SESSION_KEY = "psiguard_session_id";
+// Default interval is 60 seconds when SESSION_VALIDATION_MS is not provided
+const DEFAULT_INTERVAL = 60000;
 
 export function useSessionValidation(user: User | null, logout: () => void) {
   useEffect(() => {
     if (!user) return;
+    // Interval for checking session validity (defaults to 60s)
+    const intervalMs = parseInt(
+      process.env.SESSION_VALIDATION_MS || String(DEFAULT_INTERVAL),
+    );
     const interval = setInterval(async () => {
       try {
         const snap = await getDoc(doc(db, "users", user.id));
@@ -21,7 +27,7 @@ export function useSessionValidation(user: User | null, logout: () => void) {
       } catch (err) {
         console.error("Session validation failed", err);
       }
-    }, 60000);
+    }, intervalMs);
     return () => clearInterval(interval);
   }, [user, logout]);
 }


### PR DESCRIPTION
## Summary
- make session validation interval configurable
- document `SESSION_VALIDATION_MS` in env docs
- list `SESSION_VALIDATION_MS` in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ec020da8832496994c4738206cf4