### PR TITLE
Escape ICS newline/comma

### DIFF
--- a/src/lib/ics.ts
+++ b/src/lib/ics.ts
@@ -1,6 +1,14 @@
 import { Appointment } from "./types";
 import { format, addMinutes, parseISO } from "date-fns";
 
+function escapeText(text: string): string {
+  return text
+    .replace(/\\/g, "\\\\")
+    .replace(/\r\n|\r|\n/g, "\\n")
+    .replace(/,/g, "\\,")
+    .replace(/;/g, "\\;");
+}
+
 export function generateICS(appointments: Appointment[]): string {
   const lines = [
     "BEGIN:VCALENDAR",
@@ -17,8 +25,8 @@ export function generateICS(appointments: Appointment[]): string {
     lines.push(`DTSTAMP:${format(new Date(), "yyyyMMdd'T'HHmmss")}`);
     lines.push(`DTSTART:${format(start, "yyyyMMdd'T'HHmmss")}`);
     lines.push(`DTEND:${format(end, "yyyyMMdd'T'HHmmss")}`);
-    lines.push(`SUMMARY:Sessão com ${a.patientName}`);
-    if (a.notes) lines.push(`DESCRIPTION:${a.notes}`);
+    lines.push(`SUMMARY:${escapeText(`Sessão com ${a.patientName}`)}`);
+    if (a.notes) lines.push(`DESCRIPTION:${escapeText(a.notes)}`);
     lines.push("END:VEVENT");
   });
 

--- a/tests/ics.test.ts
+++ b/tests/ics.test.ts
@@ -1,0 +1,18 @@
+import { generateICS } from '../src/lib/ics';
+import { Appointment } from '../src/lib/types';
+
+const appointment: Appointment = {
+  id: 'a1',
+  patientId: 'p1',
+  patientName: 'Jane,\nDoe',
+  dateTime: '2024-01-01T10:00:00Z',
+  durationMinutes: 60,
+  status: 'pending',
+  notes: 'First line\nSecond line',
+};
+
+test('escape characters in SUMMARY and DESCRIPTION', () => {
+  const ics = generateICS([appointment]);
+  expect(ics).toContain('SUMMARY:Sessão com Jane\\,\\nDoe');
+  expect(ics).toContain('DESCRIPTION:First line\\nSecond line');
+});


### PR DESCRIPTION
## Summary
- escape CR, LF, comma and other special characters before inserting text in ICS export
- test escaping of newline characters in patient names and notes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ee5bc31083248e88bb976ec53793