### PR TITLE
Fix token secret assertion

### DIFF
--- a/functions/sendAssessmentLink.ts
+++ b/functions/sendAssessmentLink.ts
@@ -34,7 +34,7 @@ async function logNotification(
 
 sgMail.setApiKey(process.env.SENDGRID_API_KEY as string);
 const twilioClient = twilio(process.env.TWILIO_SID as string, process.env.TWILIO_AUTH_TOKEN as string);
-const TOKEN_SECRET = process.env.ASSESSMENT_TOKEN_SECRET;
+const TOKEN_SECRET = process.env.ASSESSMENT_TOKEN_SECRET as string;
 if (!TOKEN_SECRET) {
   throw new Error('ASSESSMENT_TOKEN_SECRET environment variable is required');
 }

--- a/functions/src/sendAssessmentLink.ts
+++ b/functions/src/sendAssessmentLink.ts
@@ -39,6 +39,9 @@ async function logNotification(
 sgMail.setApiKey(process.env.SENDGRID_API_KEY as string);
 const twilioClient = twilio(process.env.TWILIO_SID as string, process.env.TWILIO_AUTH_TOKEN as string);
 const TOKEN_SECRET = process.env.ASSESSMENT_TOKEN_SECRET as string;
+if (!TOKEN_SECRET) {
+  throw new Error('ASSESSMENT_TOKEN_SECRET environment variable is required');
+}
 const TOKEN_EXPIRY = process.env.ASSESSMENT_TOKEN_EXPIRY || '7d';
 const PUBLIC_URL = process.env.PUBLIC_URL as string;
 if (PUBLIC_URL && !PUBLIC_URL.startsWith('https://')) {


### PR DESCRIPTION
## Summary
- assert the assessment token secret as a string in Cloud Functions
- add runtime validation in the v2 function

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684460e419488324a58368a584fee92c