### PR TITLE
Fix type by passing appointments to AppointmentFormDialog

### DIFF
--- a/src/app/(app)/appointments/page.tsx
+++ b/src/app/(app)/appointments/page.tsx
@@ -193,6 +193,7 @@ export default function AppointmentsPage() {
             onOpenChange={setIsFormOpen}
             onSave={handleAddOrUpdateAppointment}
             patients={patients}
+            appointments={appointments}
             appointment={null}
           >
             <Button onClick={() => setIsFormOpen(true)} className="shadow-md">


### PR DESCRIPTION
## Summary
- ensure the second AppointmentFormDialog receives the appointments prop

## Testing
- `npm run typecheck` *(fails: functions/src/sendAssessmentLink.ts etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6844621f40d88324a75f39566d267247