### PR TITLE
Implement Firebase Scrypt hashing

### DIFF
--- a/src/lib/firebaseScrypt.ts
+++ b/src/lib/firebaseScrypt.ts
@@ -1,0 +1,41 @@
+import { createCipheriv, scrypt } from 'crypto';
+import { promisify } from 'util';
+
+const scryptAsync = promisify(scrypt);
+const IV = Buffer.alloc(16, 0);
+
+function base64decode(value: string): Buffer {
+  return Buffer.from(value.replace(/-/g, '+').replace(/_/g, '/'), 'base64');
+}
+
+export interface FirebaseHashConfig {
+  base64_signer_key: string;
+  base64_salt_separator: string;
+  rounds: number;
+  mem_cost: number;
+}
+
+export async function firebaseScryptHash(
+  password: string,
+  salt: string,
+  config: FirebaseHashConfig,
+): Promise<string> {
+  const saltBuffer = Buffer.concat([
+    base64decode(salt),
+    base64decode(config.base64_salt_separator),
+  ]);
+
+  const derivedKey = await scryptAsync(password, saltBuffer, 32, {
+    N: 2 ** config.mem_cost,
+    r: config.rounds,
+    p: 1,
+  });
+
+  const cipher = createCipheriv('aes-256-ctr', derivedKey, IV);
+  const result = Buffer.concat([
+    cipher.update(base64decode(config.base64_signer_key)),
+    cipher.final(),
+  ]);
+
+  return result.toString('base64');
+}

--- a/tests/firebaseScrypt.test.ts
+++ b/tests/firebaseScrypt.test.ts
@@ -1,0 +1,13 @@
+import { firebaseScryptHash, FirebaseHashConfig } from '../src/lib/firebaseScrypt';
+
+test('firebaseScryptHash matches expected output', async () => {
+  const config: FirebaseHashConfig = {
+    base64_signer_key: '6P1/RoypdKDx+Pldf7cH/ehGOPNuMW6o/xryOFp6u6l++KmbPDWmPZtlh2MPH1M/Qnt98+udXjku7SQ34Qx1dw==',
+    base64_salt_separator: 'Bw==',
+    rounds: 8,
+    mem_cost: 14,
+  };
+
+  const hash = await firebaseScryptHash('password', 'salt', config);
+  expect(hash).toBe('fxfkMVae9kJS9pEsZ9FwJtFSOXiDyV7OaoPakPYZDlmLMFeh6V44yA1boY+PXbOFkPcKaHfX41UaElbxP6lmyA==');
+});


### PR DESCRIPTION
## Summary
- add firebaseScryptHash utility to generate SCRYPT password hashes
- test firebaseScryptHash with example config

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844842527888324a54b0ceea75e1094