### PR TITLE
Add register to AuthContext

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,7 +1,7 @@
 /* istanbul ignore file */
 "use client";
 
-import type { User } from '@/lib/types';
+import type { User, UserRole } from '@/lib/types';
 import { useRouter } from 'next/navigation';
 import type { ReactNode } from 'react';
 import React, { createContext, useContext, useState, useEffect } from 'react';
@@ -12,6 +12,7 @@ import {
   GoogleAuthProvider,
   signInWithPopup,
   signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
   onAuthStateChanged,
   signOut,
 } from 'firebase/auth';
@@ -23,7 +24,11 @@ interface AuthContextType {
   login: (email: string, pass: string) => Promise<void>; // Simplified login
   loginWithGoogle: () => Promise<void>;
   logout: () => void;
-  // register: (email: string, pass: string, name: string) => Promise<void>; // Placeholder
+  register: (
+    email: string,
+    pass: string,
+    role: UserRole
+  ) => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -148,6 +153,40 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     }
   };
 
+  const register = async (email: string, pass: string, role: UserRole) => {
+    setIsLoading(true);
+    try {
+      const result = await createUserWithEmailAndPassword(auth, email, pass);
+      const fbUser = result.user;
+      const newSession = crypto.randomUUID();
+      const uid = fbUser.uid;
+      await setDoc(doc(db, 'users', uid), {
+        role,
+        isApproved: false,
+        email,
+        sessionId: newSession,
+      });
+
+      const mappedUser: User = {
+        id: uid,
+        name: fbUser.displayName || '',
+        email: fbUser.email || email,
+        role,
+        isApproved: false,
+        profileImage: fbUser.photoURL || undefined,
+        sessionId: newSession,
+      };
+
+      setUser(mappedUser);
+      localStorage.setItem('psiguard_user', JSON.stringify(mappedUser));
+      localStorage.setItem(SESSION_KEY, newSession);
+    } catch (err) {
+      console.error('Registration failed', err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   const loginWithGoogle = async () => {
     setIsLoading(true);
     try {
@@ -215,7 +254,17 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   useSessionValidation(user, logout);
 
   return (
-    <AuthContext.Provider value={{ user, isAuthenticated: !!user, isLoading, login, loginWithGoogle, logout }}>
+    <AuthContext.Provider
+      value={{
+        user,
+        isAuthenticated: !!user,
+        isLoading,
+        login,
+        register,
+        loginWithGoogle,
+        logout,
+      }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/tests/authContext.test.tsx
+++ b/tests/authContext.test.tsx
@@ -6,7 +6,11 @@ import { renderHook, act } from '@testing-library/react';
 import { AuthProvider, useAuth } from '../src/contexts/AuthContext';
 import { mockUser } from '../src/lib/mock-data';
 import { getDoc, setDoc, doc } from 'firebase/firestore';
-import { signOut, signInWithEmailAndPassword } from 'firebase/auth';
+import {
+  signOut,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+} from 'firebase/auth';
 import { useRouter } from 'next/navigation';
 
 jest.mock('next/navigation', () => ({ useRouter: jest.fn() }));
@@ -20,6 +24,14 @@ beforeEach(() => {
   jest.clearAllMocks();
   (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
   (signInWithEmailAndPassword as jest.Mock).mockResolvedValue({
+    user: {
+      uid: mockUser.id,
+      displayName: mockUser.name,
+      email: mockUser.email,
+      photoURL: mockUser.profileImage,
+    },
+  });
+  (createUserWithEmailAndPassword as jest.Mock).mockResolvedValue({
     user: {
       uid: mockUser.id,
       displayName: mockUser.name,
@@ -88,4 +100,32 @@ it('logout clears storage and redirects', async () => {
   expect(signOut).toHaveBeenCalled();
   expect(localStorage.getItem('psiguard_user')).toBeNull();
   expect(localStorage.getItem('psiguard_session_id')).toBeNull();
+});
+
+it('register creates user and session', async () => {
+  (setDoc as jest.Mock).mockResolvedValue(undefined);
+  (doc as jest.Mock).mockReturnValue('docref');
+
+  const { result } = renderHook(() => useAuth(), { wrapper });
+  await act(async () => {
+    await result.current.register('new@user.com', 'pass', 'PSYCHOLOGIST');
+  });
+
+  expect(createUserWithEmailAndPassword).toHaveBeenCalledWith(
+    expect.anything(),
+    'new@user.com',
+    'pass'
+  );
+  expect(setDoc).toHaveBeenCalledWith(
+    'docref',
+    expect.objectContaining({
+      role: 'PSYCHOLOGIST',
+      isApproved: false,
+      email: 'new@user.com',
+      sessionId: expect.any(String),
+    })
+  );
+  expect(result.current.isAuthenticated).toBe(true);
+  expect(localStorage.getItem('psiguard_user')).toBeTruthy();
+  expect(localStorage.getItem('psiguard_session_id')).toBeTruthy();
 });

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -6,6 +6,7 @@ jest.mock('firebase/auth', () => {
   return {
     GoogleAuthProvider: jest.fn().mockImplementation(() => ({})),
     signInWithPopup: jest.fn(),
+    createUserWithEmailAndPassword: jest.fn(),
     signInWithEmailAndPassword: jest.fn(),
     signOut: jest.fn().mockResolvedValue(undefined),
     onAuthStateChanged: jest.fn(() => () => {}),


### PR DESCRIPTION
## Summary
- add a `register` method in AuthContext
- expose the method in context provider
- mock Firebase registration in jest setup
- test registration flow

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68448a1294d08324b3fbcc52426eab4d