### PR TITLE
Ensure register defaults to pending approval

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -160,8 +160,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       const fbUser = result.user;
       const newSession = crypto.randomUUID();
       const uid = fbUser.uid;
+      // New users require admin approval before accessing the system
       await setDoc(doc(db, 'users', uid), {
         role,
+        // mark account as pending approval
         isApproved: false,
         email,
         sessionId: newSession,


### PR DESCRIPTION
## Summary
- clarify that newly registered users are flagged for admin approval

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68448cb754d08324994e2f8153599a9b