### PR TITLE
Add AES crypto helpers for Firestore

### DIFF
--- a/src/lib/aes.ts
+++ b/src/lib/aes.ts
@@ -1,0 +1,21 @@
+/* istanbul ignore file */
+import CryptoJS from 'crypto-js'
+
+// Riscos: colocar a chave de criptografia diretamente no código fonte é inseguro
+// porque ela pode ser exposta para o cliente. É melhor obtê-la de um
+// ambiente seguro (ex.: variáveis de ambiente do serviço de hospedagem)
+// e não incluí-la no bundle do aplicativo.
+function getKey(): string {
+  const key = process.env.ENCRYPTION_KEY
+  if (!key) throw new Error('ENCRYPTION_KEY não definida')
+  return key
+}
+
+export function encryptData(text: string): string {
+  return CryptoJS.AES.encrypt(text, getKey()).toString()
+}
+
+export function decryptData(encryptedText: string): string {
+  const bytes = CryptoJS.AES.decrypt(encryptedText, getKey())
+  return bytes.toString(CryptoJS.enc.Utf8)
+}

--- a/tests/aes.test.ts
+++ b/tests/aes.test.ts
@@ -1,0 +1,24 @@
+import { encryptData, decryptData } from '../src/lib/aes'
+
+beforeAll(() => {
+  process.env.ENCRYPTION_KEY = 'secret'
+})
+
+afterAll(() => {
+  delete process.env.ENCRYPTION_KEY
+})
+
+describe('encryptData/decryptData', () => {
+  const plaintext = 'segredo'
+
+  it('encryptData gera texto diferente do original', () => {
+    const cipher = encryptData(plaintext)
+    expect(cipher).not.toBe(plaintext)
+  })
+
+  it('decryptData(encryptData(texto)) retorna texto original', () => {
+    const cipher = encryptData(plaintext)
+    const plain = decryptData(cipher)
+    expect(plain).toBe(plaintext)
+  })
+})


### PR DESCRIPTION
## Summary
- add `encryptData` and `decryptData` using `crypto-js`
- include unit tests for the new helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684497f3c75c8324bebee4cb57f94b8e