### PR TITLE
Apply memoization optimizations

### DIFF
--- a/src/app/(app)/analytics/page.tsx
+++ b/src/app/(app)/analytics/page.tsx
@@ -6,7 +6,7 @@ import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@
 import { mockAppointments, mockPatients } from '@/lib/mock-data';
 import { getWeeklySessionCounts, getProblemTypeCounts, getScheduleOccupancy } from '@/lib/analytics';
 import { startOfWeek, endOfWeek, startOfMonth, endOfMonth } from 'date-fns';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { useSettings } from '@/contexts/SettingsContext';
 
 const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff8042', '#8dd1e1'];
@@ -15,8 +15,15 @@ export default function AnalyticsPage() {
   const { system } = useSettings();
   const [period, setPeriod] = useState<'week' | 'month'>('week');
 
-  const weekly = getWeeklySessionCounts(mockAppointments);
-  const problems = Object.entries(getProblemTypeCounts(mockPatients)).map(([type, count]) => ({ type, count }));
+  const weekly = useMemo(() => getWeeklySessionCounts(mockAppointments), []);
+  const problems = useMemo(
+    () =>
+      Object.entries(getProblemTypeCounts(mockPatients)).map(([type, count]) => ({
+        type,
+        count,
+      })),
+    []
+  );
 
   const now = new Date();
   const periodStart = period === 'week'
@@ -26,12 +33,16 @@ export default function AnalyticsPage() {
     ? endOfWeek(now, { weekStartsOn: 1 })
     : endOfMonth(now);
 
-  const occupancy = getScheduleOccupancy(
-    mockAppointments,
-    periodStart,
-    periodEnd,
-    system.workHoursStart,
-    system.workHoursEnd
+  const occupancy = useMemo(
+    () =>
+      getScheduleOccupancy(
+        mockAppointments,
+        periodStart,
+        periodEnd,
+        system.workHoursStart,
+        system.workHoursEnd
+      ),
+    [periodStart, periodEnd, system]
   );
 
   const occupancyData = [

--- a/src/app/(app)/analytics/psychologist/page.tsx
+++ b/src/app/(app)/analytics/psychologist/page.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useAuth } from "@/contexts/AuthContext";
 import { mockAppointments, mockPatients } from "@/lib/mock-data";
 import { startOfMonth, endOfMonth, parseISO, isWithinInterval } from "date-fns";
+import { useMemo } from "react";
 
 export default function PsychologistIndicatorsPage() {
   const { user } = useAuth();
@@ -11,15 +12,20 @@ export default function PsychologistIndicatorsPage() {
   const monthStart = startOfMonth(now);
   const monthEnd = endOfMonth(now);
 
-  const myAppointments = mockAppointments.filter(
-    (a) => a.psychologistId === user?.id,
+  const myAppointments = useMemo(
+    () => mockAppointments.filter((a) => a.psychologistId === user?.id),
+    [user]
   );
-  const monthAppts = myAppointments.filter((a) =>
-    isWithinInterval(parseISO(a.dateTime), {
-      start: monthStart,
-      end: monthEnd,
-    }),
-  );
+  const monthAppts = useMemo(
+    () =>
+      myAppointments.filter((a) =>
+        isWithinInterval(parseISO(a.dateTime), {
+          start: monthStart,
+          end: monthEnd,
+        })
+      ),
+    [myAppointments, monthStart, monthEnd]
+  ); // Filtragens memorizadas
 
   const sessionsCount = monthAppts.length;
   const absences = monthAppts.filter((a) => a.status === "absent").length;

--- a/src/app/(app)/analytics/timeline/page.tsx
+++ b/src/app/(app)/analytics/timeline/page.tsx
@@ -5,31 +5,34 @@
 import dynamic from 'next/dynamic';
 import { mockAppointments, mockPatients } from '@/lib/mock-data';
 import type { TimelineEvent } from '@/lib/types';
+import { useMemo } from 'react';
 
 const TimelineViewer = dynamic(() => import('@/components/analytics/TimelineViewer'), { ssr: false });
 
 export default function TimelinePage() {
-  const events: TimelineEvent[] = [];
-
-  mockAppointments.forEach((a) => {
-    events.push({
-      id: `appt-${a.id}`,
-      date: a.dateTime,
-      title: `Agendamento com ${a.patientName}`,
-      description: a.notes,
-    });
-  });
-
-  mockPatients.forEach((p) => {
-    p.sessionNotes.forEach((n) => {
-      events.push({
-        id: `note-${n.id}`,
-        date: n.date,
-        title: `Nota de sessão - ${p.name}`,
-        description: n.notes,
+  const events = useMemo(() => {
+    const result: TimelineEvent[] = [];
+    mockAppointments.forEach((a) => {
+      result.push({
+        id: `appt-${a.id}`,
+        date: a.dateTime,
+        title: `Agendamento com ${a.patientName}`,
+        description: a.notes,
       });
     });
-  });
+
+    mockPatients.forEach((p) => {
+      p.sessionNotes.forEach((n) => {
+        result.push({
+          id: `note-${n.id}`,
+          date: n.date,
+          title: `Nota de sessão - ${p.name}`,
+          description: n.notes,
+        });
+      });
+    });
+    return result;
+  }, []); // Eventos criados apenas uma vez
 
   return (
     <div className="space-y-6">

--- a/src/app/(app)/search/page.tsx
+++ b/src/app/(app)/search/page.tsx
@@ -3,7 +3,7 @@
 import { useSearchParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { Input } from '@/components/ui/input';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 
 // Reuse sidebar sections for search index
 const sections = [
@@ -46,7 +46,10 @@ export default function SearchPage() {
     if (q !== query) setQuery(q);
   }, [params, query]);
 
-  const results = index.filter(i => i.label.toLowerCase().includes(query.toLowerCase()));
+  const results = useMemo(
+    () => index.filter(i => i.label.toLowerCase().includes(query.toLowerCase())),
+    [query]
+  ); // useMemo para filtrar somente quando 'query' mudar
 
   return (
     <div className="max-w-lg mx-auto space-y-4">

--- a/src/components/AssistantWidget.tsx
+++ b/src/components/AssistantWidget.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { MessageCircle } from "lucide-react";
 import { useTransformersPipeline } from "@/hooks/useTransformersPipeline";
 
@@ -18,7 +18,7 @@ export default function AssistantWidget() {
   const loading = modelLoading || sending;
   const containerRef = useRef<HTMLDivElement>(null);
 
-  async function send() {
+  const send = useCallback(async () => {
     const text = input.trim();
     if (!text) return;
     setMessages((m) => [...m, { sender: "user", text }]);
@@ -36,14 +36,17 @@ export default function AssistantWidget() {
       const utter = new SpeechSynthesisUtterance(reply);
       speechSynthesis.speak(utter);
     }
-  }
+  }, [generator, input]);
 
-  function handleKey(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
-      send();
-    }
-  }
+  const handleKey = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        send();
+      }
+    },
+    [send]
+  );
 
   useEffect(() => {
     const div = containerRef.current;

--- a/src/components/analytics/SymptomHeatmap.tsx
+++ b/src/components/analytics/SymptomHeatmap.tsx
@@ -2,6 +2,7 @@
 
 import type { SymptomHeatmapEntry } from "@/lib/types";
 import { eachDayOfInterval, startOfMonth, endOfMonth, format } from "date-fns";
+import { useMemo } from "react";
 
 interface SymptomHeatmapProps {
   entries: SymptomHeatmapEntry[];
@@ -9,29 +10,33 @@ interface SymptomHeatmapProps {
 
 export default function SymptomHeatmap({ entries }: SymptomHeatmapProps) {
   const now = new Date();
-  const days = eachDayOfInterval({
-    start: startOfMonth(now),
-    end: endOfMonth(now),
-  });
 
-  const severityByDate: Record<string, number> = {};
-  entries.forEach((e) => {
-    severityByDate[e.date.slice(0, 10)] = e.severity;
-  });
+  const { days, severityByDate, weeks } = useMemo(() => {
+    const days = eachDayOfInterval({
+      start: startOfMonth(now),
+      end: endOfMonth(now),
+    });
 
-  const weeks: (Date | null)[][] = [];
-  let current: (Date | null)[] = Array(days[0].getDay()).fill(null);
-  days.forEach((d) => {
-    current.push(d);
-    if (current.length === 7) {
+    const severityByDate: Record<string, number> = {};
+    entries.forEach((e) => {
+      severityByDate[e.date.slice(0, 10)] = e.severity;
+    });
+
+    const weeks: (Date | null)[][] = [];
+    let current: (Date | null)[] = Array(days[0].getDay()).fill(null);
+    days.forEach((d) => {
+      current.push(d);
+      if (current.length === 7) {
+        weeks.push(current);
+        current = [];
+      }
+    });
+    if (current.length) {
+      while (current.length < 7) current.push(null);
       weeks.push(current);
-      current = [];
     }
-  });
-  if (current.length) {
-    while (current.length < 7) current.push(null);
-    weeks.push(current);
-  }
+    return { days, severityByDate, weeks };
+  }, [entries]); // useMemo para evitar recálculos
 
   const colors = [
     "bg-gray-200",

--- a/src/components/analytics/TimelineViewer.tsx
+++ b/src/components/analytics/TimelineViewer.tsx
@@ -2,15 +2,20 @@
 
 import type { TimelineEvent } from '@/lib/types';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { useMemo } from 'react';
 
 interface TimelineViewerProps {
   events: TimelineEvent[];
 }
 
 export default function TimelineViewer({ events }: TimelineViewerProps) {
-  const sorted = [...events].sort(
-    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
-  );
+  const sorted = useMemo(
+    () =>
+      [...events].sort(
+        (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+      ),
+    [events]
+  ); // useMemo para evitar nova ordenação em cada render
   return (
     <div className="space-y-4">
       {sorted.map((event) => (

--- a/src/components/appointments/AppointmentCalendarView.tsx
+++ b/src/components/appointments/AppointmentCalendarView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo, useCallback } from "react";
 import {
   Card,
   CardContent,
@@ -113,60 +113,82 @@ export function AppointmentCalendarView({
     return "outline";
   };
 
-  const filtered = appointments
-    .filter((a) =>
-      (!selectedDate || isSameDay(parseISO(a.dateTime), selectedDate)) &&
-      (statusFilter === "all" || a.status === statusFilter) &&
-      (showCanceled || a.status !== "canceled")
-    )
-    .sort((a, b) => parseISO(a.dateTime).getTime() - parseISO(b.dateTime).getTime());
+  const filtered = useMemo(() => {
+    return appointments
+      .filter(
+        (a) =>
+          (!selectedDate || isSameDay(parseISO(a.dateTime), selectedDate)) &&
+          (statusFilter === "all" || a.status === statusFilter) &&
+          (showCanceled || a.status !== "canceled")
+      )
+      .sort(
+        (a, b) => parseISO(a.dateTime).getTime() - parseISO(b.dateTime).getTime()
+      );
+  }, [appointments, selectedDate, statusFilter, showCanceled]);
 
-  const blocks = parseBlockedTimes(system.blockedTimes, system.defaultSessionDuration);
-  const weekly = parseWeeklyBlockedTimes(system.weeklyBlockedTimes);
-  const dailyBlocks: BlockedTime[] = [];
-  blocks.forEach((b) => {
-    if (!selectedDate || isSameDay(parseISO(b.dateTime), selectedDate)) dailyBlocks.push(b);
-  });
-  if (selectedDate) {
-    weekly.forEach((w) => {
-      if (selectedDate.getDay() === w.weekday) {
-        const [sh, sm] = w.start.split(":" ).map(Number);
-        const [eh, em] = w.end.split(":" ).map(Number);
-        const start = new Date(selectedDate);
-        start.setHours(sh, sm, 0, 0);
-        const duration = eh * 60 + em - (sh * 60 + sm);
-        dailyBlocks.push({
-          id: `w-${w.id}-${format(selectedDate, "yyyyMMdd")}`,
-          dateTime: start.toISOString(),
-          durationMinutes: duration,
-          reason: w.reason,
-        });
-      }
+  const { dailyBlocks, combined } = useMemo(() => {
+    const blocks = parseBlockedTimes(
+      system.blockedTimes,
+      system.defaultSessionDuration
+    );
+    const weekly = parseWeeklyBlockedTimes(system.weeklyBlockedTimes);
+    const dailyBlocks: BlockedTime[] = [];
+    blocks.forEach((b) => {
+      if (!selectedDate || isSameDay(parseISO(b.dateTime), selectedDate))
+        dailyBlocks.push(b);
     });
-  }
+    if (selectedDate) {
+      weekly.forEach((w) => {
+        if (selectedDate.getDay() === w.weekday) {
+          const [sh, sm] = w.start.split(":" ).map(Number);
+          const [eh, em] = w.end.split(":" ).map(Number);
+          const start = new Date(selectedDate);
+          start.setHours(sh, sm, 0, 0);
+          const duration = eh * 60 + em - (sh * 60 + sm);
+          dailyBlocks.push({
+            id: `w-${w.id}-${format(selectedDate, "yyyyMMdd")}`,
+            dateTime: start.toISOString(),
+            durationMinutes: duration,
+            reason: w.reason,
+          });
+        }
+      });
+    }
+    type CombinedItem =
+      | { type: "appt"; appt: Appointment }
+      | { type: "block"; block: BlockedTime };
+    const combined: CombinedItem[] = [
+      ...filtered.map((a) => ({ type: "appt", appt: a } as const)),
+      ...dailyBlocks.map((b) => ({ type: "block", block: b } as const)),
+    ].sort((a, b) => {
+      const da =
+        a.type === "appt"
+          ? parseISO(a.appt.dateTime)
+          : parseISO(a.block.dateTime);
+      const db =
+        b.type === "appt"
+          ? parseISO(b.appt.dateTime)
+          : parseISO(b.block.dateTime);
+      return da.getTime() - db.getTime();
+    });
+    return { dailyBlocks, combined };
+  }, [filtered, selectedDate, system]); // useMemo reduz cálculos
 
-  type CombinedItem = { type: "appt"; appt: Appointment } | { type: "block"; block: BlockedTime };
-  const combined: CombinedItem[] = [
-    ...filtered.map((a) => ({ type: "appt", appt: a } as const)),
-    ...dailyBlocks.map((b) => ({ type: "block", block: b } as const)),
-  ].sort((a, b) => {
-    const da = a.type === "appt" ? parseISO(a.appt.dateTime) : parseISO(a.block.dateTime);
-    const db = b.type === "appt" ? parseISO(b.appt.dateTime) : parseISO(b.block.dateTime);
-    return da.getTime() - db.getTime();
-  });
-
-  const handleEdit = (appt: Appointment) => {
+  const handleEdit = useCallback((appt: Appointment) => {
     setEditingAppointment(appt);
     setIsFormOpen(true);
-  };
+  }, []);
 
-  const handleDelete = (id: string) => {
-    onDeleteAppointment(id);
-    toast({
-      title: "Agendamento Excluído",
-      variant: "destructive",
-    });
-  };
+  const handleDelete = useCallback(
+    (id: string) => {
+      onDeleteAppointment(id);
+      toast({
+        title: "Agendamento Excluído",
+        variant: "destructive",
+      });
+    },
+    [onDeleteAppointment, toast]
+  );
 
   const handleStatusChange = (id: string, status: AttendanceStatus) => {
     const appt = appointments.find((a) => a.id === id);

--- a/src/components/appointments/AppointmentFormDialog.tsx
+++ b/src/components/appointments/AppointmentFormDialog.tsx
@@ -50,7 +50,7 @@ import {
 } from "date-fns";
 import type { Appointment, Patient } from "@/lib/types";
 import { generateRecurringAppointments } from "@/lib/recurrence";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 
 const formSchema = z.object({
   patientName: z.string().min(2, { message: "Nome é obrigatório." }),
@@ -150,12 +150,14 @@ export function AppointmentFormDialog({
     }
   }, [appointment, form, isOpen]);
 
-  const timeOptions = Array.from({ length: 24 * 2 }, (_, i) => {
-    const total = i * 30;
-    const h = String(Math.floor(total / 60)).padStart(2, "0");
-    const m = String(total % 60).padStart(2, "0");
-    return `${h}:${m}`;
-  });
+  const timeOptions = useMemo(() => {
+    return Array.from({ length: 48 }, (_, i) => {
+      const total = i * 30;
+      const h = String(Math.floor(total / 60)).padStart(2, "0");
+      const m = String(total % 60).padStart(2, "0");
+      return `${h}:${m}`;
+    });
+  }, []); // useMemo para calcular apenas uma vez
 
   async function onSubmit(values: FormValues) {
     setIsLoading(true);

--- a/src/components/templates/TemplateTable.tsx
+++ b/src/components/templates/TemplateTable.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
 import { FilePenLine, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { SmartModal } from "@/components/SmartModal";
 import { useToast } from "@/hooks/use-toast";
 import { TemplateFormDialog } from "./TemplateFormDialog";
@@ -28,20 +28,23 @@ export function TemplateTable({ templates, onSave, onDelete }: TemplateTableProp
   const [toDelete, setToDelete] = useState<Template | null>(null);
   const { toast } = useToast();
 
-  const handleEdit = (template: Template) => {
+  const handleEdit = useCallback((template: Template) => {
     setEditing(template);
     setIsFormOpen(true);
-  };
+  }, []);
 
-  const handleSave = (tpl: Template) => {
-    onSave(tpl);
-    toast({
-      title: editing ? "Modelo Atualizado" : "Modelo Criado",
-      description: `O modelo ${tpl.name} foi salvo com sucesso.`,
-    });
-    setEditing(null);
-    setIsFormOpen(false);
-  };
+  const handleSave = useCallback(
+    (tpl: Template) => {
+      onSave(tpl);
+      toast({
+        title: editing ? "Modelo Atualizado" : "Modelo Criado",
+        description: `O modelo ${tpl.name} foi salvo com sucesso.`,
+      });
+      setEditing(null);
+      setIsFormOpen(false);
+    },
+    [editing, onSave, toast]
+  );
 
   const handleDelete = (id: string, name: string) => {
     onDelete(id);


### PR DESCRIPTION
## Summary
- memoize sorted events in `TimelineViewer`
- cache heavy calculations in `SymptomHeatmap`
- reduce recalculations in `AppointmentCalendarView` and stabilize handlers
- stabilize handlers in `TemplateTable`
- memoize functions in `AssistantWidget`
- cache time options in `AppointmentFormDialog`
- memoize search results
- memoize analytics data
- cache timeline events and psychologist indicators

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm test` *(fails: 4 failed, 8 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6844dff5e5788324a18936bc1bc4b3f8