### PR TITLE
Update Node version retrieval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - id: node-version
-        run: echo "version=$(node -p \"require('./package.json').engines?.node || '20'\")" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(node -e \"console.log(require('./package.json').engines?.node || '20')\")" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- simplify the CI workflow command used to detect Node.js version

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68450045623c8324812b563784460bf2