### PR TITLE
Validate CRYPTO_SECRET_KEY

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -4,7 +4,7 @@ NEXT_PUBLIC_FIREBASE_PROJECT_ID=your_project_id
 NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your_project.appspot.com
 NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your_messaging_sender_id
 NEXT_PUBLIC_FIREBASE_APP_ID=your_firebase_app_id
-# Não use esta chave em produção!
+# Chave AES de 32 bytes codificada em base64 (não use em produção!)
 CRYPTO_SECRET_KEY=REPLACE_ME_BASE64_32BYTES
 
 # Service account JSON string for Firebase Admin SDK

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your_project.appspot.com
 NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
 NEXT_PUBLIC_FIREBASE_APP_ID=your_app_id
 
-# 🔐 Chave de criptografia AES-256-GCM (32 bytes base64).
+# 🔐 Chave de criptografia AES-256-GCM (32 bytes codificada em base64).
 # NÃO use esta chave em produção!
 CRYPTO_SECRET_KEY=REPLACE_ME_BASE64_32BYTES
 ```
@@ -40,7 +40,7 @@ CRYPTO_SECRET_KEY=REPLACE_ME_BASE64_32BYTES
 | `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` | Bucket do Storage | não |
 | `NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID` | ID do Cloud Messaging | não |
 | `NEXT_PUBLIC_FIREBASE_APP_ID` | ID do aplicativo Firebase | não |
-| `CRYPTO_SECRET_KEY` | Chave AES para criptografar dados sensíveis | não |
+| `CRYPTO_SECRET_KEY` | Chave AES em base64 para criptografar dados sensíveis | não |
 | `FIREBASE_SERVICE_ACCOUNT` | JSON da conta de serviço para o Admin SDK | não |
 | `ASSESSMENT_TOKEN_SECRET` | Segredo para assinar links de inventários | não |
 | `ASSESSMENT_TOKEN_EXPIRY` | Validade dos links de inventário (padrão 7d) | sim |

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -15,7 +15,12 @@ export function getCryptoKey(): Buffer {
     }
     throw new Error("CRYPTO_SECRET_KEY is not set");
   }
-  cachedKey = Buffer.from(key, "base64");
+  const trimmed = key.trim();
+  const buf = Buffer.from(trimmed, "base64");
+  if (buf.toString("base64") !== trimmed || buf.length !== 32) {
+    throw new Error("CRYPTO_SECRET_KEY must be a valid base64-encoded 32-byte key");
+  }
+  cachedKey = buf;
   return cachedKey;
 }
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -54,3 +54,13 @@ describe('CPF utilities', () => {
     expect(isValidCPF('111.111.111-11')).toBe(false);
   });
 });
+
+test('getCryptoKey throws for invalid base64', () => {
+  const original = process.env.CRYPTO_SECRET_KEY;
+  process.env.CRYPTO_SECRET_KEY = 'not_base64';
+  jest.isolateModules(() => {
+    const { getCryptoKey } = require('../src/lib/utils');
+    expect(() => getCryptoKey()).toThrow(/base64/);
+  });
+  process.env.CRYPTO_SECRET_KEY = original;
+});


### PR DESCRIPTION
## Summary
- document that CRYPTO_SECRET_KEY must be base64 encoded
- validate crypto key encoding at runtime
- add test for invalid key case

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68452c5261088324b318890651a29ef9