### PR TITLE
Enable assistant widget with transformers

### DIFF
--- a/src/hooks/useTransformersPipeline.ts
+++ b/src/hooks/useTransformersPipeline.ts
@@ -1,10 +1,10 @@
 "use client";
 
 import { useState, useEffect } from "react";
-// import type { TextGenerationPipeline } from "@xenova/transformers";
+import type { TextGenerationPipeline } from "@xenova/transformers";
 
 export function useTransformersPipeline(open: boolean) {
-  const [generator, setGenerator] = useState<any>(null);
+  const [generator, setGenerator] = useState<TextGenerationPipeline | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -21,18 +21,21 @@ export function useTransformersPipeline(open: boolean) {
         setLoading(true);
         setError(null);
         try {
-          // const mod = await import("@xenova/transformers");
-          // const pipe = (await mod.pipeline(
-          //   "text-generation",
-          //   "Xenova/gpt2",
-          //   { quantized: true }
-          // )) as TextGenerationPipeline;
-          // if (!cancelled) {
-          //   setGenerator(pipe);
-          // }
+          const mod = await import("@xenova/transformers");
+          const pipe = (await mod.pipeline(
+            "text-generation",
+            "Xenova/gpt2",
+            { quantized: true }
+          )) as TextGenerationPipeline;
+          if (!cancelled) {
+            setGenerator(pipe);
+          }
         } catch (err) {
           console.error("Failed to load model", err);
-          if (!cancelled) setError("Falha ao carregar o modelo");
+          if (!cancelled) {
+            setError("Falha ao carregar o modelo");
+            setGenerator(null);
+          }
         } finally {
           if (!cancelled) setLoading(false);
         }


### PR DESCRIPTION
## Summary
- re-enable `@xenova/transformers` in the assistant hook

## Testing
- `npm install`
- `npm test` *(fails: Jest global coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68452c50f3488324882bf07dd552afaf