### PR TITLE
Implement Firebase auth session

### DIFF
--- a/src/app/(app)/assessments/library/page.tsx
+++ b/src/app/(app)/assessments/library/page.tsx
@@ -1,11 +1,18 @@
-import { adminDb } from '@/lib/firebaseAdmin';
-import { TestMeta } from '@/lib/types';
-import ApplyTestModal from '@/components/assessments/ApplyTestModal';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { adminDb } from '@/lib/firebaseAdmin'
+import { TestMeta } from '@/lib/types'
+import ApplyTestModal from '@/components/assessments/ApplyTestModal'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { getCurrentUser } from '@/lib/session'
+import { redirect } from 'next/navigation'
 
 export default async function LibraryPage() {
-  const snap = await adminDb.collection('testsLibrary').get();
-  const tests: TestMeta[] = snap.docs.map(d => ({ id: d.id, ...(d.data() as Omit<TestMeta, 'id'>) }));
+  const user = await getCurrentUser()
+  if (!user) {
+    redirect('/login')
+  }
+
+  const snap = await adminDb.collection('testsLibrary').get()
+  const tests: TestMeta[] = snap.docs.map(d => ({ id: d.id, ...(d.data() as Omit<TestMeta, 'id'>) }))
 
   return (
     <div className="space-y-4">

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,15 +1,18 @@
 // Caminho: src/lib/session.ts
 
+import { cookies } from 'next/headers'
+import { adminAuth } from './firebaseAdmin'
+
 // IMPORTANTE: Este é um arquivo de exemplo. Você deve adaptá-lo
 // para o seu provedor de autenticação (Next-Auth, Clerk, Firebase Admin, etc.).
 
 // Definindo um tipo básico para o usuário. Adicione mais campos se necessário.
 interface UserSession {
-    id: string;
-    name?: string | null;
-    email?: string | null;
-    role?: string; // Ex: 'psychologist', 'admin'
-  }
+  id: string
+  name?: string | null
+  email?: string | null
+  role?: string // Ex: 'psychologist', 'admin'
+}
   
   /**
    * Obtém os dados do usuário logado na sessão atual do servidor.
@@ -17,23 +20,21 @@ interface UserSession {
    * 
    * @returns {Promise<UserSession | null>} Retorna o objeto do usuário se logado, ou null se não estiver.
    */
-  export async function getCurrentUser(): Promise<UserSession | null> {
-    // --- IMPLEMENTAÇÃO SIMULADA PARA DESENVOLVIMENTO ---
-    // Este trecho faz o código funcionar imediatamente, simulando um usuário logado.
-    // Lembre-se de substituir isso pela lógica real do seu sistema de login!
-    
-    console.warn(
-      "AVISO DE DESENVOLVIMENTO: A função getCurrentUser() está usando dados simulados. Implemente a lógica real de autenticação."
-    );
-  
-    // Para testar, você pode retornar este objeto de usuário:
+export async function getCurrentUser(): Promise<UserSession | null> {
+  const cookieStore = cookies()
+  const token = cookieStore.get('idToken')?.value
+  if (!token) return null
+
+  try {
+    const decoded = await adminAuth.verifyIdToken(token)
     return {
-      id: "user_psicologo_abc456",
-      name: "Dra. Ana Maria",
-      email: "ana.maria@exemplo.com",
-      role: "psychologist"
-    };
-    
-    // Para testar um cenário de usuário deslogado, descomente a linha abaixo e comente o bloco acima:
-    // return null;
+      id: decoded.uid,
+      name: decoded.name ?? null,
+      email: decoded.email ?? null,
+      role: (decoded as any).role,
+    }
+  } catch (err) {
+    console.error('Failed to verify Firebase ID token', err)
+    return null
   }
+}


### PR DESCRIPTION
## Summary
- verify Firebase ID token from cookies in `getCurrentUser`
- guard assessments library page using this auth helper

## Testing
- `npm install`
- `npm test` *(fails: encryptPatient not found, authContext tests fail, firebaseAdmin requires service account)*

------
https://chatgpt.com/codex/tasks/task_e_68452c4f8ba483248b597f0e0c21de31