### PR TITLE
Fix firestore imports in patients page

### DIFF
--- a/src/app/(app)/patients/page.tsx
+++ b/src/app/(app)/patients/page.tsx
@@ -9,7 +9,7 @@ import { useToast } from "@/hooks/use-toast";
 
 // --- 1. IMPORTAÇÕES ATUALIZADAS ---
 import { db } from '@/lib/firebaseClient';
-import { collection, onSnapshot, addDoc, updateDoc, doc, setDoc } from 'firebase/firestore';
+import { collection, onSnapshot, deleteDoc, doc, setDoc } from 'firebase/firestore';
 import { encryptPatientObject } from '@/lib/patient-utils'; // <-- Usando nosso novo utilitário!
 
 // Componentes da UI (sem alteração)


### PR DESCRIPTION
## Summary
- import `deleteDoc` instead of unused `addDoc`/`updateDoc`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find modules)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68452c4ebfe483249c4ed393a9bcf3f1