### PR TITLE
Add notifications hook with tests

### DIFF
--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState, useCallback } from 'react';
+import { v4 as uuid } from 'uuid';
+
+export interface Notification {
+  id: string;
+  message: string;
+  type: string;
+}
+
+interface AddNotificationOptions {
+  message: string;
+  type: string;
+  duration?: number;
+}
+
+export default function useNotifications() {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+
+  const removeNotification = useCallback((id: string) => {
+    setNotifications((prev) => prev.filter((n) => n.id !== id));
+  }, []);
+
+  const addNotification = useCallback(
+    ({ message, type, duration }: AddNotificationOptions) => {
+      const id = uuid();
+      setNotifications((prev) => [...prev, { id, message, type }]);
+
+      if (duration) {
+        setTimeout(() => removeNotification(id), duration);
+      }
+    },
+    [removeNotification]
+  );
+
+  return {
+    notifications,
+    addNotification,
+    removeNotification,
+  };
+}

--- a/tests/hooks/useNotifications.test.ts
+++ b/tests/hooks/useNotifications.test.ts
@@ -1,0 +1,74 @@
+import { renderHook, act } from '@testing-library/react';
+import useNotifications from '../../src/hooks/useNotifications';
+
+jest.mock('uuid', () => ({
+  v4: () => 'test-uuid',
+}));
+
+describe('Hook: useNotifications', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  test('deve iniciar com uma lista de notificações vazia', () => {
+    const { result } = renderHook(() => useNotifications());
+    expect(result.current.notifications).toHaveLength(0);
+  });
+
+  test('deve adicionar uma nova notificação quando addNotification é chamada', () => {
+    const { result } = renderHook(() => useNotifications());
+
+    act(() => {
+      result.current.addNotification({ message: 'Sucesso!', type: 'success' });
+    });
+
+    expect(result.current.notifications).toHaveLength(1);
+    expect(result.current.notifications[0]).toMatchObject({
+      id: 'test-uuid',
+      message: 'Sucesso!',
+      type: 'success',
+    });
+  });
+
+  test('deve remover uma notificação quando removeNotification é chamada', () => {
+    const { result } = renderHook(() => useNotifications());
+
+    act(() => {
+      result.current.addNotification({ message: 'Para remover', type: 'info' });
+    });
+
+    expect(result.current.notifications).toHaveLength(1);
+    const notificationId = result.current.notifications[0].id;
+
+    act(() => {
+      result.current.removeNotification(notificationId);
+    });
+
+    expect(result.current.notifications).toHaveLength(0);
+  });
+
+  test('deve remover a notificação automaticamente após a duração especificada', () => {
+    const { result } = renderHook(() => useNotifications());
+
+    act(() => {
+      result.current.addNotification({
+        message: 'Auto-remove',
+        type: 'warning',
+        duration: 5000,
+      });
+    });
+
+    expect(result.current.notifications).toHaveLength(1);
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(result.current.notifications).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add a simple `useNotifications` hook for managing local notifications
- test adding, removing and auto-clearing of notifications

## Testing
- `npx jest tests/hooks/useNotifications.test.ts --runInBand` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_684ac197905c8324aa7d262431e5498e