### PR TITLE
Edit jest config to break and restore test script

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,4 @@
+isso-vai-quebrar-o-arquivo;
 const nextJest = require('next/jest');
 
 const createJestConfig = nextJest({

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test": "echo 'MEU ARQUIVO FOI SALVO CORRETAMENTE!'"
+    "test": "firebase emulators:exec --project demo-project jest --only firestore"
   },
   "dependencies": {
     "@auth/firebase-adapter": "^1.0.15",


### PR DESCRIPTION
## Summary
- restore the original npm test script
- add a breaking line to `jest.config.js`

## Testing
- `npm test` *(fails: Script "jest" exited with code 127)*

------
https://chatgpt.com/codex/tasks/task_e_684ad45a4b408324b402922962b29c98