### PR TITLE
Configure Jest multi-project

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,27 +1,22 @@
-isso-vai-quebrar-o-arquivo;
-const nextJest = require('next/jest');
-
-const createJestConfig = nextJest({
-  // Fornece o caminho para o seu aplicativo Next.js para carregar next.config.js e .env em seu ambiente de teste
-  dir: './',
-});
-
-// Adiciona qualquer configuração personalizada a ser passada para o Jest
 /** @type {import('jest').Config} */
-const customJestConfig = {
-  setupFilesAfterEnv: ['<rootDir>/tests/jest.setup.ts'],
-  testEnvironment: 'jest-environment-jsdom',
-  // Aumenta o tempo limite de 5s para 15s para os testes do emulador
-  testTimeout: 15000,
-  // Mapeia os aliases de caminho do tsconfig.json para o Jest
-  moduleNameMapper: {
-    '^@/(.*)$': '<rootDir>/src/$1',
-  },
-  // Corrige o erro de sintaxe de módulos ESM como o lucide-react
-  transformIgnorePatterns: [
-    '/node_modules/(?!lucide-react)/',
-  ],
+module.exports = {
+  projects: [
+    {
+      displayName: 'rules',
+      testMatch: ['<rootDir>/__tests__/**/*rules.test.ts'],
+      testEnvironment: 'node',
+      setupFilesAfterEnv: ['<rootDir>/jest.setup.rules.ts'],
+      moduleNameMapper: { '^src/(.*)$': '<rootDir>/src/$1' }
+    },
+    {
+      displayName: 'ui',
+      testMatch: ['<rootDir>/__tests__/**/*.(test|spec).tsx', '<rootDir>/tests/**/*.(test|spec).tsx'],
+      preset: "next/jest",
+      testEnvironment: 'jsdom',
+      transformIgnorePatterns: [
+        '/node_modules/(?!(lucide-react)/)'
+      ],
+      moduleNameMapper: { '^src/(.*)$': '<rootDir>/src/$1' }
+    }
+  ]
 };
-
-// createJestConfig é exportado desta forma para garantir que next/jest possa carregar a configuração do Next.js que é assíncrona
-module.exports = createJestConfig(customJestConfig);

--- a/jest.setup.rules.ts
+++ b/jest.setup.rules.ts
@@ -1,0 +1,6 @@
+// 1) aumentar timeout global p/ evitar falhas de bootstrap
+jest.setTimeout(20000);
+
+// 2) polyfill setImmediate caso rode em algum runner que não tenha
+(global as any).setImmediate =
+  (global as any).setImmediate || ((fn: any, ...args: any[]) => setTimeout(fn, 0, ...args));


### PR DESCRIPTION
## Summary
- fix broken jest.config.js
- use Next.js preset in a multi-project setup
- add rule tests setup helper

## Testing
- `npm test` *(fails: `firebase` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ad7d3345483248db10445cc99dd50