### PR TITLE
Fix test script to use emulator

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test": "npx firebase emulators:exec --project demo-project jest --only firestore"
+    "test": "npx firebase emulators:exec --project demo-project \"npx jest\""
   },
   "dependencies": {
     "@auth/firebase-adapter": "^1.0.15",


### PR DESCRIPTION
## Summary
- update `test` script to invoke Jest inside firebase emulator

## Testing
- `npm test` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_684adb6e83b083249273473fd1b97280