### PR TITLE
Add audit trail mock UI

### DIFF
--- a/src/app/(app)/tools/audit-trail/page.tsx
+++ b/src/app/(app)/tools/audit-trail/page.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Badge,
+} from "@/components/ui/badge";
 import {
   Table,
   TableBody,
@@ -9,43 +17,61 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { format } from "date-fns";
 
-interface AuditEntry {
+type AuditLog = {
   id: string;
-  timestamp: string;
-  user: string;
-  action: string;
-  details?: string;
-}
+  timestamp: Date;
+  user: {
+    name: string;
+    role: "Admin" | "Psychologist";
+  };
+  action: "LOGIN" | "VIEW_PATIENT" | "EDIT_APPOINTMENT" | "GENERATE_REPORT";
+  details: string;
+};
 
-const mockData: AuditEntry[] = [
+const mockData: AuditLog[] = [
   {
     id: "1",
-    timestamp: new Date().toISOString(),
-    user: "admin@example.com",
+    timestamp: new Date(),
+    user: { name: "Alice", role: "Admin" },
     action: "LOGIN",
-    details: "Usuário realizou login no sistema",
+    details: "Acesso realizado ao sistema",
   },
   {
     id: "2",
-    timestamp: new Date(Date.now() - 1000 * 60 * 60).toISOString(),
-    user: "psicologo@example.com",
-    action: "VIEW_PATIENT_RECORD",
-    details: "Visualizou prontuário do paciente #123",
+    timestamp: new Date(Date.now() - 1000 * 60 * 5),
+    user: { name: "Bruno", role: "Psychologist" },
+    action: "VIEW_PATIENT",
+    details: "Visualizou ficha do paciente #123",
   },
   {
     id: "3",
-    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(),
-    user: "psicologo@example.com",
-    action: "UPDATE_SESSION_NOTE",
-    details: "Atualizou nota da sessão 456",
+    timestamp: new Date(Date.now() - 1000 * 60 * 30),
+    user: { name: "Clara", role: "Psychologist" },
+    action: "EDIT_APPOINTMENT",
+    details: "Editou consulta agendada para 02/04",
+  },
+  {
+    id: "4",
+    timestamp: new Date(Date.now() - 1000 * 60 * 60),
+    user: { name: "Davi", role: "Admin" },
+    action: "GENERATE_REPORT",
+    details: "Gerou relatório mensal de atendimentos",
+  },
+  {
+    id: "5",
+    timestamp: new Date(Date.now() - 1000 * 60 * 90),
+    user: { name: "Eduarda", role: "Psychologist" },
+    action: "VIEW_PATIENT",
+    details: "Acessou histórico do paciente #456",
   },
 ];
 
 export default function AuditTrailPage() {
   return (
     <div className="space-y-6">
-      <h1 className="text-3xl font-bold font-headline">Trilha de Auditoria</h1>
+      <h1 className="text-3xl font-bold font-headline">Trilha de Auditoria do Sistema</h1>
       <Card className="shadow-lg rounded-lg">
         <CardHeader>
           <CardTitle>Logs Registrados</CardTitle>
@@ -63,11 +89,25 @@ export default function AuditTrailPage() {
             <TableBody>
               {mockData.map((log) => (
                 <TableRow key={log.id}>
-                  <TableCell>{new Date(log.timestamp).toLocaleString()}</TableCell>
-                  <TableCell>{log.user}</TableCell>
-                  <TableCell>{log.action}</TableCell>
+                  <TableCell>{format(log.timestamp, "dd/MM/yyyy HH:mm:ss")}</TableCell>
+                  <TableCell>
+                    {log.user.name} ({log.user.role})
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={
+                      log.action === "LOGIN"
+                        ? "default"
+                        : log.action === "VIEW_PATIENT"
+                        ? "secondary"
+                        : log.action === "EDIT_APPOINTMENT"
+                        ? "destructive"
+                        : "outline"
+                    }>
+                      {log.action}
+                    </Badge>
+                  </TableCell>
                   <TableCell className="max-w-xs truncate">
-                    {log.details || "-"}
+                    {log.details}
                   </TableCell>
                 </TableRow>
               ))}


### PR DESCRIPTION
## Summary
- display audit trail log table with mock data
- show formatted date, user role, and badge for actions

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ade27cd008324b957a8cd189749f5