### PR TITLE
Fix Jest config and Firebase CLI

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,17 +1,25 @@
-const nextJest = require('next/jest')({ dir: './' });
-/** @type {import('jest').Config} */
-module.exports = {
-  projects: [
-    {
-      displayName: 'rules',
-      testMatch: ['<rootDir>/__tests__/**/*rules.test.ts'],
-      testEnvironment: 'node',
-      setupFilesAfterEnv: ['<rootDir>/jest.setup.rules.ts']
-    },
-    nextJest({
-      displayName: 'ui',
-      testMatch: ['<rootDir>/__tests__/**/*.test.tsx'],
-      transformIgnorePatterns: ['/node_modules/(?!lucide-react)']
-    })
-  ]
+const createJestConfig = require('next/jest')({ dir: './' });
+
+const uiConfig = {
+  displayName: 'ui',
+  testMatch: ['<rootDir>/tests/**/*.test.ts?(x)', '<rootDir>/__tests__/**/*.test.ts?(x)'],
+  moduleNameMapper: {
+    '^lucide-react$': 'lucide-react/dist/cjs/lucide-react.js'
+  },
+  transformIgnorePatterns: ['/node_modules/(?!(lucide-react)/)']
+};
+
+module.exports = async () => {
+  const ui = await createJestConfig(uiConfig)();
+  return {
+    projects: [
+      {
+        displayName: 'rules',
+        testMatch: ['<rootDir>/__tests__/**/*rules.test.ts'],
+        testEnvironment: 'node',
+        setupFilesAfterEnv: ['<rootDir>/jest.setup.rules.ts']
+      },
+      ui
+    ]
+  };
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test": "npx firebase emulators:exec --project demo-project jest --only firestore"
+    "test": "npm run build:rules && ./node_modules/.bin/firebase emulators:exec --project demo-project \"npm run jest\" --only firestore",
+    "jest": "jest",
+    "build:rules": "echo 'building rules if you need' >/dev/null"
   },
   "dependencies": {
     "@auth/firebase-adapter": "^1.0.15",


### PR DESCRIPTION
## Summary
- ensure the Firebase CLI is called from node_modules
- configure UI Jest project with Next.js helper and lucide-react mapping

## Testing
- `npm test` *(fails: Script "npm run jest" exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_684adb24af188324ae835e13b68a2fea