### PR TITLE
Add audit trail page links and docs

### DIFF
--- a/__tests__/pages/auditTrail.test.tsx
+++ b/__tests__/pages/auditTrail.test.tsx
@@ -1,0 +1,21 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import AuditTrailPage from '@/app/(app)/tools/audit-trail/page';
+import { navigation } from '@/lib/navigation';
+
+describe('Page: AuditTrail', () => {
+  it('renders table with mock entries', () => {
+    render(<AuditTrailPage />);
+    expect(screen.getByRole('heading', { name: /Trilha de Auditoria/i })).toBeInTheDocument();
+    expect(screen.getByRole('table')).toBeInTheDocument();
+  });
+});
+
+describe('Navigation', () => {
+  it('includes audit trail route', () => {
+    expect(navigation.some((n) => n.href === '/tools/audit-trail')).toBe(true);
+  });
+});

--- a/docs/audit-trail.md
+++ b/docs/audit-trail.md
@@ -1,0 +1,12 @@
+# Página de Trilha de Auditoria
+
+A Trilha de Auditoria exibe registros detalhados de todas as ações realizadas no sistema. 
+Esta interface foi criada com componentes shadcn/ui para manter a consistência visual do PsiGuard.
+
+- **Rota**: `/tools/audit-trail`
+- **Objetivo**: oferecer transparência e controle para administradores.
+
+O layout utiliza um card contendo uma tabela com data, usuário, ação e detalhes. 
+Os dados apresentados no ambiente de desenvolvimento são mockados e servem apenas para validar a disposição das informações.
+
+A página segue os princípios de densidade informacional e clareza do projeto, facilitando auditorias rápidas sem distrações.

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -96,6 +96,12 @@ export const navigation: NavItem[] = [
     category: 'Ferramentas',
   },
   {
+    label: 'Trilha de Auditoria',
+    description: 'Registros completos de todas as ações no sistema.',
+    href: '/tools/audit-trail',
+    category: 'Sistema',
+  },
+  {
     label: 'Configura\u00e7\u00f5es',
     description: 'Personalize prefer\u00eancias e integra\u00e7\u00f5es do sistema.',
     href: '/settings',


### PR DESCRIPTION
## Summary
- register audit trail in navigation menu
- document design for the audit trail feature
- add unit test confirming page render and navigation entry

## Testing
- `npx jest --runInBand` *(fails: Need to install the following packages: jest@30.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_684ade0a9b4083248ba077dc4d620929