### PR TITLE
Implement therapeutic groups pages

### DIFF
--- a/src/app/(app)/groups/[id]/page.tsx
+++ b/src/app/(app)/groups/[id]/page.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ArrowLeft } from "lucide-react";
+
+import type { Group } from "../page";
+
+const mockGroups: Group[] = [
+  { id: "g1", name: "Grupo de Ansiedade", therapist: "Dr. Carlos", participants: 8 },
+  { id: "g2", name: "Mindfulness Semanal", therapist: "Dra. Ana", participants: 12 },
+  { id: "g3", name: "Apoio a Adolescentes", therapist: "Dr. Pedro", participants: 10 },
+];
+
+export default function GroupDetailPage({ params }: { params: { id: string } }) {
+  const group = mockGroups.find((g) => g.id === params.id);
+  const router = useRouter();
+
+  if (!group) {
+    return (
+      <div className="p-4">
+        <p>Grupo não encontrado.</p>
+        <button onClick={() => router.back()} className="text-blue-600 underline">
+          Voltar
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <Link href="/groups" className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
+        <ArrowLeft className="h-4 w-4" /> Voltar
+      </Link>
+      <Card className="max-w-md">
+        <CardHeader>
+          <CardTitle>{group.name}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-1 text-sm text-muted-foreground">
+          <p>Terapeuta Responsável: {group.therapist}</p>
+          <p>Número de Participantes: {group.participants}</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(app)/groups/page.tsx
+++ b/src/app/(app)/groups/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export type Group = {
+  id: string;
+  name: string;
+  therapist: string;
+  participants: number;
+};
+
+const mockGroups: Group[] = [
+  {
+    id: "g1",
+    name: "Grupo de Ansiedade",
+    therapist: "Dr. Carlos",
+    participants: 8,
+  },
+  {
+    id: "g2",
+    name: "Mindfulness Semanal",
+    therapist: "Dra. Ana",
+    participants: 12,
+  },
+  {
+    id: "g3",
+    name: "Apoio a Adolescentes",
+    therapist: "Dr. Pedro",
+    participants: 10,
+  },
+];
+
+export default function GroupsPage() {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold font-headline">Grupos Terapêuticos</h1>
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {mockGroups.map((group) => (
+          <Link href={`/groups/${group.id}`} key={group.id}>
+            <Card className="hover:shadow-md transition-shadow cursor-pointer">
+              <CardHeader>
+                <CardTitle className="text-base font-medium">
+                  {group.name}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="text-sm text-muted-foreground space-y-1">
+                <p>Terapeuta: {group.therapist}</p>
+                <p>Participantes: {group.participants}</p>
+              </CardContent>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add main page to list therapy groups with mock data
- add detail page for individual therapy group

## Testing
- `npm test` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_684ae51b40d48324a545fc6d7ed80351