### PR TITLE
Add initial profile page UI

### DIFF
--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useAuth } from '@/contexts/AuthContext';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from '@/components/ui/form';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+const nameSchema = z.object({
+  name: z.string().min(2, { message: 'Nome obrigatório' }),
+});
+
+type NameFormValues = z.infer<typeof nameSchema>;
+
+function getInitials(name?: string) {
+  if (!name) return 'U';
+  const names = name.split(' ');
+  if (names.length > 1) {
+    return `${names[0][0]}${names[names.length - 1][0]}`.toUpperCase();
+  }
+  return name.substring(0, 2).toUpperCase();
+}
+
+export default function ProfilePage() {
+  const { user } = useAuth();
+
+  const form = useForm<NameFormValues>({
+    resolver: zodResolver(nameSchema),
+    defaultValues: {
+      name: user?.name || '',
+    },
+  });
+
+  const onSubmit = (values: NameFormValues) => {
+    // Futuro: enviar ao backend
+    console.log(values);
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-6">
+      <Card className="shadow-lg">
+        <CardHeader>
+          <CardTitle className="font-headline text-2xl">Perfil</CardTitle>
+          <CardDescription>Informações do usuário</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center space-x-4">
+            <Avatar className="h-16 w-16">
+              <AvatarImage
+                src={user?.profileImage || `https://placehold.co/100x100.png?text=${getInitials(user?.name)}`}
+                alt={user?.name || 'Usuário'}
+              />
+              <AvatarFallback>{getInitials(user?.name)}</AvatarFallback>
+            </Avatar>
+            <div>
+              <p className="text-lg font-medium">{user?.name}</p>
+              <p className="text-sm text-muted-foreground">{user?.email}</p>
+              <p className="text-sm text-muted-foreground capitalize">{user?.role?.toLowerCase()}</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="shadow-lg">
+        <CardHeader>
+          <CardTitle className="font-headline text-xl">Alterar Nome</CardTitle>
+          <CardDescription>Funcionalidade em desenvolvimento</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Nome</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Seu nome" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <Button type="submit" disabled className="cursor-not-allowed">
+                Salvar
+              </Button>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add static profile page using card and form components
- include a disabled form for updating the name

## Testing
- `npx next lint` *(fails: Need to install next)*
- `npm run test` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_684ae55cf0f483249c3511d4c33d13f2