### PR TITLE
Add admin metrics page

### DIFF
--- a/src/app/(app)/admin/metrics/page.tsx
+++ b/src/app/(app)/admin/metrics/page.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import StatsCard from "@/components/dashboard/stats-card";
+import {
+  Users,
+  CalendarCheck,
+  UserPlus,
+} from "lucide-react";
+
+export default function AdminMetricsPage() {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold font-headline">Métricas do Sistema</h1>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        <StatsCard
+          icon={Users}
+          title="Total de Pacientes Ativos"
+          value={128}
+        />
+        <StatsCard
+          icon={CalendarCheck}
+          title="Sessões Realizadas no Mês"
+          value={42}
+        />
+        <StatsCard
+          icon={UserPlus}
+          title="Novos Usuários Pendentes"
+          value={5}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/stats-card.tsx
+++ b/src/components/dashboard/stats-card.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { LucideIcon } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface StatsCardProps {
+  icon: LucideIcon;
+  title: string;
+  value: React.ReactNode;
+  description?: string;
+  children?: React.ReactNode;
+}
+
+export default function StatsCard({
+  icon: Icon,
+  title,
+  value,
+  description,
+  children,
+}: StatsCardProps) {
+  return (
+    <Card className="shadow-md rounded-xl">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium">{title}</CardTitle>
+        <Icon className="h-5 w-5 opacity-10" />
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-bold">{value}</div>
+        {description && <p className="text-xs text-muted-foreground">{description}</p>}
+        {children}
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- add `StatsCard` component for dashboard stats
- create Admin Metrics page with static metrics

## Testing
- `npm test` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_684ae54bc7cc8324a7626140ce77bae1