### PR TITLE
Add template editor page

### DIFF
--- a/src/app/(app)/templates/new/page.tsx
+++ b/src/app/(app)/templates/new/page.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { TemplateEditor } from "@/components/forms/template-editor";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import { useRouter } from "next/navigation";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+
+const schema = z.object({
+  name: z.string().min(2, { message: "Nome é obrigatório." }),
+  content: z.string().min(1, { message: "Conteúdo é obrigatório." }),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+export default function NewTemplatePage() {
+  const router = useRouter();
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { name: "", content: "" },
+  });
+
+  const onSubmit = (values: FormValues) => {
+    console.log(values); // placeholder for API call
+    router.push("/templates");
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-headline font-bold">Novo Modelo</h1>
+        <p className="text-muted-foreground">Crie um modelo reutilizável.</p>
+      </div>
+      <Card className="shadow-lg rounded-lg">
+        <CardHeader>
+          <CardTitle>Informações do Modelo</CardTitle>
+          <CardDescription>Defina nome e conteúdo.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Nome do Modelo</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Título" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="content"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Conteúdo</FormLabel>
+                    <FormControl>
+                      <TemplateEditor
+                        value={field.value}
+                        onChange={field.onChange}
+                        className="min-h-[200px]"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <div className="flex justify-end gap-2 pt-4">
+                <Button type="button" variant="outline" onClick={() => router.back()}>
+                  Cancelar
+                </Button>
+                <Button type="submit">Salvar</Button>
+              </div>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(app)/templates/page.tsx
+++ b/src/app/(app)/templates/page.tsx
@@ -6,14 +6,11 @@ import { mockTemplates } from '@/lib/mock-data';
 import { TemplateTable } from '@/components/templates/TemplateTable';
 import { Button } from '@/components/ui/button';
 import { PlusCircle } from 'lucide-react';
-import { TemplateFormDialog } from '@/components/templates/TemplateFormDialog';
+import Link from 'next/link';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { useToast } from '@/hooks/use-toast';
 
 export default function TemplatesPage() {
   const [templates, setTemplates] = useState<Template[]>([]);
-  const [isFormOpen, setIsFormOpen] = useState(false);
-  const { toast } = useToast();
 
   useEffect(() => {
     setTemplates(mockTemplates);
@@ -40,11 +37,11 @@ export default function TemplatesPage() {
           <h1 className="text-3xl font-bold font-headline">Modelos</h1>
           <p className="text-muted-foreground">Gerencie modelos reutilizáveis.</p>
         </div>
-        <TemplateFormDialog onSave={handleSave} isOpen={isFormOpen} onOpenChange={setIsFormOpen}>
-          <Button onClick={() => setIsFormOpen(true)} className="shadow-md">
-            <PlusCircle className="mr-2 h-5 w-5" /> Novo Modelo
-          </Button>
-        </TemplateFormDialog>
+        <Button asChild className="shadow-md">
+          <Link href="/templates/new" className="flex items-center gap-2">
+            <PlusCircle className="h-5 w-5" /> Novo Modelo
+          </Link>
+        </Button>
       </div>
 
       <Card className="shadow-lg rounded-lg">

--- a/src/components/forms/template-editor.tsx
+++ b/src/components/forms/template-editor.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEditor, EditorContent } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import Underline from "@tiptap/extension-underline";
+import { useEffect } from "react";
+import clsx from "clsx";
+
+interface TemplateEditorProps {
+  value: string;
+  onChange: (content: string) => void;
+  className?: string;
+}
+
+export function TemplateEditor({ value, onChange, className }: TemplateEditorProps) {
+  const editor = useEditor({
+    extensions: [StarterKit, Underline],
+    content: value,
+    onUpdate({ editor }) {
+      onChange(editor.getHTML());
+    },
+  });
+
+  useEffect(() => {
+    if (editor && value !== editor.getHTML()) {
+      editor.commands.setContent(value);
+    }
+  }, [value, editor]);
+
+  return (
+    <div className={clsx("border rounded-md p-2", className)}>
+      <EditorContent editor={editor} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add TemplateEditor component using Tiptap
- add `/templates/new` page to create templates
- link from templates list to the new page

## Testing
- `npm test` *(fails: could not determine executable)*

------
https://chatgpt.com/codex/tasks/task_e_684ae53b41e88324a33f9f621c381a2e