### PR TITLE
Add Notifications section to settings

### DIFF
--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -19,6 +19,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { SettingsForm } from "@/components/forms/settings-form";
+import { useState } from "react";
 
 export default function SettingsPage() {
   const { dashboard, updateDashboard, system, updateSystem } = useSettings();
@@ -31,6 +33,10 @@ export default function SettingsPage() {
     (key: keyof typeof system) => (value: string | boolean) => {
       updateSystem({ [key]: value } as any);
     };
+
+  const [emailNotifications, setEmailNotifications] = useState(false);
+  const [taskNotifications, setTaskNotifications] = useState(false);
+  const [agendaNotifications, setAgendaNotifications] = useState(false);
 
   return (
     <div className="space-y-6">
@@ -165,6 +171,33 @@ export default function SettingsPage() {
           </div>
         </CardContent>
       </Card>
+
+      <SettingsForm
+        title="Notificações"
+        description="Gerencie suas preferências de notificação."
+      >
+        <label className="flex items-center gap-2">
+          <Switch
+            checked={emailNotifications}
+            onCheckedChange={setEmailNotifications}
+          />
+          Receber notificações por e-mail
+        </label>
+        <label className="flex items-center gap-2">
+          <Switch
+            checked={taskNotifications}
+            onCheckedChange={setTaskNotifications}
+          />
+          Notificar sobre novas tarefas
+        </label>
+        <label className="flex items-center gap-2">
+          <Switch
+            checked={agendaNotifications}
+            onCheckedChange={setAgendaNotifications}
+          />
+          Avisar sobre alterações na agenda
+        </label>
+      </SettingsForm>
     </div>
   );
 }

--- a/src/components/forms/settings-form.tsx
+++ b/src/components/forms/settings-form.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import React from "react";
+
+export interface SettingsFormProps {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function SettingsForm({ title, description, children, className }: SettingsFormProps) {
+  return (
+    <Card className={cn("shadow-lg max-w-md", className)}>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        {description && <CardDescription>{description}</CardDescription>}
+      </CardHeader>
+      <CardContent className="space-y-4">{children}</CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- implement a reusable `SettingsForm` component
- add `Notificações` section on the settings page with toggles

## Testing
- `npm test` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_684ae5aa3d408324b4d5398fbf637e1e