### PR TITLE
feat(auth): server-side AuthGuard

### DIFF
--- a/src/app/(app)/dashboard/layout.tsx
+++ b/src/app/(app)/dashboard/layout.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import AuthGuard from '@/components/AuthGuard'
+import type { UserRole } from '@/lib/types'
+
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <AuthGuard role={'PSYCHOLOGIST' as UserRole}>
+      {children}
+    </AuthGuard>
+  )
+}

--- a/src/components/AuthGuard.tsx
+++ b/src/components/AuthGuard.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { redirect } from 'next/navigation'
+import { getCurrentUser } from '@/lib/session'
+import type { UserRole } from '@/lib/types'
+
+interface AuthGuardProps {
+  children: React.ReactNode
+  role: UserRole
+}
+
+export default async function AuthGuard({ children, role }: AuthGuardProps) {
+  const user = await getCurrentUser()
+
+  if (!user || user.role !== role) {
+    redirect('/login')
+  }
+
+  return <>{children}</>
+}

--- a/tests/authGuard.test.tsx
+++ b/tests/authGuard.test.tsx
@@ -1,0 +1,32 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import AuthGuard from '../src/components/AuthGuard'
+import { getCurrentUser } from '../src/lib/session'
+import { redirect } from 'next/navigation'
+
+jest.mock('../src/lib/session', () => ({ getCurrentUser: jest.fn() }))
+jest.mock('next/navigation', () => ({ redirect: jest.fn() }))
+
+describe('AuthGuard', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders children when user has role', async () => {
+    ;(getCurrentUser as jest.Mock).mockResolvedValue({ id: '1', role: 'PSYCHOLOGIST' })
+
+    const element = await AuthGuard({ role: 'PSYCHOLOGIST', children: <div>ok</div> })
+    render(<>{element}</>)
+    expect(screen.getByText('ok')).toBeInTheDocument()
+  })
+
+  it('redirects when role mismatch', async () => {
+    ;(getCurrentUser as jest.Mock).mockResolvedValue({ id: '1', role: 'ADMIN' })
+
+    await AuthGuard({ role: 'PSYCHOLOGIST', children: <div>ok</div> })
+    expect(redirect).toHaveBeenCalledWith('/login')
+  })
+})


### PR DESCRIPTION
## Summary
- add `AuthGuard` server component for role-based access
- apply `AuthGuard` to dashboard layout
- test `AuthGuard` rendering with mocked auth

## Testing
- `npm ci --quiet` *(fails: could not resolve dependencies)*
- `npm run jest -- -t AuthGuard` *(fails: jest not found after failed install)*

------
https://chatgpt.com/codex/tasks/task_e_684ae9cdb7348324b6b4df1f18bdecec