### PR TITLE
chore(ui): clinical risk tokens

### DIFF
--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -1,0 +1,13 @@
+# Guia de Estilo
+
+Este documento apresenta exemplos de componentes utilizando as cores de risco clínico.
+
+### Badge de risco
+
+Use as classes `bg-risk-low`, `bg-risk-medium` e `bg-risk-high` para representar os diferentes níveis.
+
+```tsx
+<Badge className="bg-risk-low text-white">Baixo</Badge>
+<Badge className="bg-risk-medium text-white">Médio</Badge>
+<Badge className="bg-risk-high text-white">Alto</Badge>
+```

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,6 +25,10 @@
     --accent: 177 70% 45%; /* Turquoise */
     --accent-foreground: 210 40% 15%;
 
+    --risk-low: 147 60% 40%;
+    --risk-medium: 30 100% 45%;
+    --risk-high: 0 70% 50%;
+
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
 
@@ -72,6 +76,10 @@
 
     --accent: 177 70% 55%;
     --accent-foreground: 177 100% 15%;
+
+    --risk-low: 147 40% 55%;
+    --risk-medium: 30 90% 60%;
+    --risk-high: 0 80% 60%;
 
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -44,6 +44,9 @@ export default {
           foreground: 'hsl(var(--accent-foreground))',
         },
         warning: colors.amber,
+        'risk-low': 'hsl(var(--risk-low))',
+        'risk-medium': 'hsl(var(--risk-medium))',
+        'risk-high': 'hsl(var(--risk-high))',
         destructive: {
           DEFAULT: 'hsl(var(--destructive))',
           foreground: 'hsl(var(--destructive-foreground))',


### PR DESCRIPTION
## Summary
- define `risk-low`, `risk-medium` and `risk-high` colors in Tailwind
- expose the new tokens via CSS variables for light and dark themes
- document risk badge usage in `docs/styleguide.md`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684ae9f452088324a8242f42b00e54da