### PR TITLE
chore(dev): emulator backup script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "jest": "jest",
-    "test": "npx firebase emulators:exec --project demo-project \"npm run jest\""
+    "test": "npx firebase emulators:exec --project demo-project \"npm run jest\"",
+    "backup": "node scripts/backup.js"
   },
   "dependencies": {
     "@auth/firebase-adapter": "^1.0.15",

--- a/scripts/backup.js
+++ b/scripts/backup.js
@@ -1,0 +1,15 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+async function main() {
+  const date = new Date().toISOString().slice(0, 10);
+  const dir = path.join(__dirname, '..', 'backups', `dev-${date}`);
+  fs.mkdirSync(dir, { recursive: true });
+  execSync(`npx firebase emulators:export ${dir}`, { stdio: 'inherit' });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a backup script exporting emulator data via firebase-tools
- expose `npm run backup`

## Testing
- `npm run lint` *(fails: Failed to load config "prettier" to extend from)*
- `npm run typecheck` *(fails: TS2307 Cannot find module 'dotenv' or its corresponding type declarations, etc.)*
- `npm test` *(fails: Build failed because of webpack errors)*
- `npm run build` *(fails: Build failed because of webpack errors)*


------
https://chatgpt.com/codex/tasks/task_e_684aea4aaa0883248a5cf790b9597ef1