### PR TITLE
feat(rules): harden users/patients access

### DIFF
--- a/__tests__/rules/users.spec.ts
+++ b/__tests__/rules/users.spec.ts
@@ -1,0 +1,54 @@
+import { initializeTestEnvironment, assertSucceeds, assertFails } from '@firebase/rules-unit-testing';
+import { readFileSync } from 'fs';
+import { doc, getDoc, setDoc, updateDoc } from 'firebase/firestore';
+
+describe('users security rules', () => {
+  let testEnv: any;
+
+  beforeAll(async () => {
+    testEnv = await initializeTestEnvironment({
+      projectId: 'demo-project',
+      firestore: { rules: readFileSync('docs/firestore.rules', 'utf8') }
+    });
+  });
+
+  afterAll(async () => {
+    await testEnv.cleanup();
+  });
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+  });
+
+  it('allows a user to read their own document', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx: any) => {
+      await setDoc(doc(ctx.firestore(), 'users/alice'), { role: 'PSYCHOLOGIST' });
+    });
+    const alice = testEnv.authenticatedContext('alice', { role: 'PSYCHOLOGIST' });
+    await assertSucceeds(getDoc(doc(alice.firestore(), 'users/alice')));
+  });
+
+  it('denies a user reading another user', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx: any) => {
+      await setDoc(doc(ctx.firestore(), 'users/bob'), { role: 'PSYCHOLOGIST' });
+    });
+    const alice = testEnv.authenticatedContext('alice', { role: 'PSYCHOLOGIST' });
+    await assertFails(getDoc(doc(alice.firestore(), 'users/bob')));
+  });
+
+  it('allows admin to update any user', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx: any) => {
+      await setDoc(doc(ctx.firestore(), 'users/bob'), { role: 'PSYCHOLOGIST' });
+    });
+    const admin = testEnv.authenticatedContext('admin', { role: 'ADMIN' });
+    await assertSucceeds(updateDoc(doc(admin.firestore(), 'users/bob'), { role: 'ADMIN' }));
+  });
+
+  it('denies non-admin updating other user', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx: any) => {
+      await setDoc(doc(ctx.firestore(), 'users/bob'), { role: 'PSYCHOLOGIST' });
+    });
+    const alice = testEnv.authenticatedContext('alice', { role: 'PSYCHOLOGIST' });
+    await assertFails(updateDoc(doc(alice.firestore(), 'users/bob'), { role: 'PSYCHOLOGIST' }));
+  });
+});

--- a/docs/firestore.rules
+++ b/docs/firestore.rules
@@ -5,10 +5,20 @@ service cloud.firestore {
       return request.auth != null && request.auth.token.role == 'PSYCHOLOGIST';
     }
 
+    function isAdmin() {
+      return request.auth != null && request.auth.token.role == 'ADMIN';
+    }
+
+    function indexedQuery() {
+      return request.query == null || request.query.orderBy.size() > 0;
+    }
+
     // Users can only manage their own document
     match /users/{userId} {
-      allow create, read, update, delete:
-          if request.auth != null && request.auth.uid == userId;
+      allow get, create, update, delete:
+          if request.auth != null &&
+             (request.auth.uid == userId || isAdmin());
+      allow list: if isAdmin() && indexedQuery();
     }
 
     // Posts: creation requires matching authorId. Update and delete allowed
@@ -24,6 +34,18 @@ service cloud.firestore {
 
     match /testsLibrary/{testId} {
       allow read: if isPsychologist();
+    }
+
+    match /patients/{patientId} {
+      allow get, update, delete:
+          if request.auth != null &&
+             (isAdmin() ||
+              (isPsychologist() && resource.data.psychologistId == request.auth.uid));
+      allow create:
+          if request.auth != null &&
+             (isAdmin() ||
+              (isPsychologist() && request.resource.data.psychologistId == request.auth.uid));
+      allow list: if isAdmin() && indexedQuery();
     }
 
     match /patients/{patientId}/assessments/{assessmentId} {

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,10 @@ module.exports = {
   projects: [
     {
       displayName: 'rules',
-      testMatch: ['<rootDir>/__tests__/**/*rules.test.ts'],
+      testMatch: [
+        '<rootDir>/__tests__/**/*rules.test.ts',
+        '<rootDir>/__tests__/rules/**/*.spec.ts'
+      ],
       testEnvironment: 'node',
       setupFilesAfterEnv: ['<rootDir>/jest.setup.rules.ts']
     },

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "ts-node": "^10.9.2",
     "tsx": "^4.7.0",
     "typescript": "5.3.3",
-    "firebase-tools": "^14.6.0"
+    "firebase-tools": "^14.6.0",
+    "@firebase/rules-unit-testing": "^3.0.4"
   }
 }


### PR DESCRIPTION
## Summary
- restrict `/users/{uid}` access to self or admins
- add patient owner and admin checks
- forbid unindexed queries using helper
- support `*.spec.ts` in jest config
- add Jest tests for user rules

## Testing
- `npx jest` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae9c0aab8832497b9a62a6d3e206b