### PR TITLE
Add loop coverage tests and comments

### DIFF
--- a/src/lib/availability.ts
+++ b/src/lib/availability.ts
@@ -1,9 +1,9 @@
-import { addMinutes, getDay, parseISO } from 'date-fns';
-import type { BlockedTime, WeeklyBlockedTime } from './types';
+import { addMinutes, getDay, parseISO } from "date-fns";
+import type { BlockedTime, WeeklyBlockedTime } from "./types";
 
 export function parseBlockedTimes(
   text: string,
-  durationMinutes = 60
+  durationMinutes = 60,
 ): BlockedTime[] {
   return text
     .split(/[,\n;]/)
@@ -23,7 +23,7 @@ export function parseWeeklyBlockedTimes(text: string): WeeklyBlockedTime[] {
     .filter(Boolean)
     .map((entry, idx) => {
       const [dayStr, timeRange] = entry.split(/\s+/);
-      const [start, end] = timeRange.split('-');
+      const [start, end] = timeRange.split("-");
       return {
         id: `wblk-${idx}`,
         weekday: parseInt(dayStr, 10),
@@ -36,17 +36,19 @@ export function parseWeeklyBlockedTimes(text: string): WeeklyBlockedTime[] {
 export function isDateTimeBlocked(
   date: Date,
   blocks: BlockedTime[],
-  weekly: WeeklyBlockedTime[]
+  weekly: WeeklyBlockedTime[],
 ): boolean {
+  // Check each explicit blocked interval once
   for (const b of blocks) {
     const start = parseISO(b.dateTime);
     const end = addMinutes(start, b.durationMinutes);
     if (date >= start && date < end) return true;
   }
+  // Then evaluate weekly recurring blocks
   for (const w of weekly) {
     if (getDay(date) === w.weekday) {
-      const [sh, sm] = w.start.split(':').map(Number);
-      const [eh, em] = w.end.split(':').map(Number);
+      const [sh, sm] = w.start.split(":").map(Number);
+      const [eh, em] = w.end.split(":").map(Number);
       const start = new Date(date);
       start.setHours(sh, sm, 0, 0);
       const end = new Date(date);

--- a/tests/availability.test.ts
+++ b/tests/availability.test.ts
@@ -1,0 +1,59 @@
+import {
+  parseBlockedTimes,
+  parseWeeklyBlockedTimes,
+  isDateTimeBlocked,
+} from "../src/lib/availability";
+import { addMinutes } from "date-fns";
+
+const baseIso = "2024-01-01T10:00:00Z";
+
+describe("parseBlockedTimes", () => {
+  it("returns empty array for empty input", () => {
+    expect(parseBlockedTimes("")).toEqual([]);
+  });
+
+  it("parses multiple iso strings", () => {
+    const blocks = parseBlockedTimes(`${baseIso},2024-01-02T11:00:00Z`);
+    expect(blocks.length).toBe(2);
+    expect(blocks[0]).toMatchObject({ id: "blk-0", dateTime: baseIso });
+    expect(blocks[1].id).toBe("blk-1");
+  });
+});
+
+describe("parseWeeklyBlockedTimes", () => {
+  it("returns empty array for empty input", () => {
+    expect(parseWeeklyBlockedTimes("")).toEqual([]);
+  });
+
+  it("parses weekday ranges", () => {
+    const weekly = parseWeeklyBlockedTimes("1 09:00-10:00,3 14:00-15:00");
+    expect(weekly.length).toBe(2);
+    expect(weekly[0]).toMatchObject({
+      id: "wblk-0",
+      weekday: 1,
+      start: "09:00",
+      end: "10:00",
+    });
+    expect(weekly[1].weekday).toBe(3);
+  });
+});
+
+describe("isDateTimeBlocked", () => {
+  const blocks = parseBlockedTimes(baseIso);
+  const weekly = parseWeeklyBlockedTimes("2 10:00-11:00");
+
+  it("detects explicit block", () => {
+    const date = new Date(baseIso);
+    expect(isDateTimeBlocked(date, blocks, [])).toBe(true);
+  });
+
+  it("detects weekly block", () => {
+    const tuesday = new Date("2024-01-02T10:30:00Z");
+    expect(isDateTimeBlocked(tuesday, [], weekly)).toBe(true);
+  });
+
+  it("returns false when not blocked", () => {
+    const date = addMinutes(new Date(baseIso), 120);
+    expect(isDateTimeBlocked(date, blocks, weekly)).toBe(false);
+  });
+});

--- a/tests/patient-utils.test.ts
+++ b/tests/patient-utils.test.ts
@@ -1,0 +1,47 @@
+import {
+  encryptPatientObject,
+  decryptPatientObject,
+} from "../src/lib/patient-utils";
+import { Patient } from "../src/lib/types";
+
+beforeAll(() => {
+  process.env.CRYPTO_SECRET_KEY = Buffer.alloc(32).toString("base64");
+});
+
+afterAll(() => {
+  delete process.env.CRYPTO_SECRET_KEY;
+});
+
+const patient: Patient = {
+  id: "p1",
+  name: "Test",
+  contact: "123",
+  cpf: "11122233344",
+  dateOfBirth: "2000-01-01",
+  sessionNotes: [],
+  treatmentPlan: "plan",
+};
+
+describe("encryptPatientObject/decryptPatientObject", () => {
+  it("handles empty arrays and strings", () => {
+    const enc = encryptPatientObject({ ...patient, sessionNotes: [] });
+    const dec = decryptPatientObject(enc);
+    expect(dec.sessionNotes).toEqual([]);
+  });
+
+  it("round trips all sensitive fields", () => {
+    const enc = encryptPatientObject(patient);
+    for (const key of [
+      "contact",
+      "cpf",
+      "dateOfBirth",
+      "sessionNotes",
+      "treatmentPlan",
+    ]) {
+      // @ts-ignore
+      expect(enc[key]).not.toBe(patient[key]);
+    }
+    const dec = decryptPatientObject(enc);
+    expect(dec).toEqual(patient);
+  });
+});


### PR DESCRIPTION
## Summary
- document loops in `isDateTimeBlocked`
- add unit tests for availability utilities
- add unit tests for patient utility helpers

## Testing
- `npx prettier -w tests/availability.test.ts tests/patient-utils.test.ts`
- `npx prettier -w src/lib/availability.ts`
- `npm install` *(fails: dependency resolution)*
- `npx jest` *(fails: tried to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_684b6edd0118832487b67f54da9e82f0