### PR TITLE
Add copy-to-clipboard for patient email

### DIFF
--- a/src/components/CopyToClipboardButton.tsx
+++ b/src/components/CopyToClipboardButton.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useState } from "react";
+import { Copy, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/hooks/use-toast";
+
+interface CopyToClipboardButtonProps {
+  text: string;
+  className?: string;
+}
+
+export default function CopyToClipboardButton({ text, className }: CopyToClipboardButtonProps) {
+  const [copied, setCopied] = useState(false);
+  const { toast } = useToast();
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      toast({ title: "Copiado!" });
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      toast({
+        title: "Erro ao copiar",
+        description: "Não foi possível copiar para a área de transferência.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      size="icon"
+      variant="ghost"
+      onClick={handleCopy}
+      className={className}
+    >
+      {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+      <span className="sr-only">Copiar</span>
+    </Button>
+  );
+}

--- a/src/components/patients/PatientDetailsClient.tsx
+++ b/src/components/patients/PatientDetailsClient.tsx
@@ -9,6 +9,7 @@ import { db } from '@/lib/firebaseClient';
 
 // --- 1. IMPORTAÇÃO ATUALIZADA ---
 import { decryptPatientObject } from '@/lib/patient-utils'; // <-- Usando nosso novo utilitário!
+import CopyToClipboardButton from '@/components/CopyToClipboardButton';
 
 // Componente para exibir um esqueleto de carregamento (opcional, mas recomendado)
 const PatientDetailsSkeleton = () => (
@@ -87,7 +88,10 @@ export function PatientDetailsClient({ patientId }: { patientId: string }) {
     <div className="p-4 border rounded-lg shadow-sm bg-white">
       <h2 className="text-2xl font-bold font-headline text-gray-800 mb-4">{patient.name}</h2>
       <div className="space-y-2 text-gray-600">
-        <p><strong>Email:</strong> {patient.email || 'Não informado'}</p>
+        <div className="flex items-center gap-2">
+          <p className="m-0"><strong>Email:</strong> {patient.email || 'Não informado'}</p>
+          {patient.email && <CopyToClipboardButton text={patient.email} />}
+        </div>
         <p><strong>CPF:</strong> {patient.cpf}</p> {/* <-- EXIBINDO O CPF REAL E DESCRIPTOGRAFADO */}
         <p><strong>Contato:</strong> {patient.contact}</p>
         <p><strong>Data de Nascimento:</strong> {patient.dateOfBirth}</p>


### PR DESCRIPTION
## Summary
- add reusable `CopyToClipboardButton`
- use the button in `PatientDetailsClient` to copy email

## Testing
- `npm test` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_684b7039ef788324ab048961fd170bbe