### PR TITLE
Fix redirect paths for unauthenticated access

### DIFF
--- a/src/app/(app)/assessments/library/page.tsx
+++ b/src/app/(app)/assessments/library/page.tsx
@@ -8,7 +8,7 @@ import { redirect } from 'next/navigation'
 export default async function LibraryPage() {
   const user = await getCurrentUser()
   if (!user) {
-    redirect('/dashboard')
+    redirect('/login')
   }
 
   const snap = await adminDb.collection('testsLibrary').get()

--- a/src/app/(app)/dashboard/users/page.tsx
+++ b/src/app/(app)/dashboard/users/page.tsx
@@ -6,7 +6,7 @@ import { redirect } from 'next/navigation';
 export default async function DashboardUsersPage() {
   const user = await getCurrentUser();
   if (!user) {
-    redirect('/dashboard');
+    redirect('/login');
   }
 
   const users = await getUsers();


### PR DESCRIPTION
## Summary
- correct redirect routes on protected pages

## Testing
- `npm run jest --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b71c483cc83249de89881b44c228e