### PR TITLE
Add session inactivity timeout hook

### DIFF
--- a/src/hooks/use-session-timeout.tsx
+++ b/src/hooks/use-session-timeout.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from 'react';
+
+const DEFAULT_TIMEOUT = 15 * 60 * 1000; // 15 minutes
+
+/**
+ * Hook que detecta inatividade do usuário e executa `onTimeout` após um período definido.
+ * Listeners de eventos reiniciam o timer sempre que o usuário demonstra atividade.
+ */
+export function useSessionTimeout(
+  onTimeout: () => void,
+  timeoutMs: number = DEFAULT_TIMEOUT
+) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Limpa o timer atual
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  // Inicia (ou reinicia) o timer de inatividade
+  const startTimer = useCallback(() => {
+    clearTimer();
+    timerRef.current = setTimeout(() => {
+      onTimeout();
+    }, timeoutMs);
+  }, [clearTimer, onTimeout, timeoutMs]);
+
+  // Handler para qualquer evento de atividade
+  const handleActivity = useCallback(() => {
+    startTimer();
+  }, [startTimer]);
+
+  useEffect(() => {
+    // Inicia o timer assim que o hook monta
+    startTimer();
+
+    const events = ['mousemove', 'keydown', 'scroll'];
+    events.forEach((evt) => window.addEventListener(evt, handleActivity));
+
+    // Limpa os listeners e o timer ao desmontar
+    return () => {
+      clearTimer();
+      events.forEach((evt) => window.removeEventListener(evt, handleActivity));
+    };
+  }, [handleActivity, clearTimer, startTimer]);
+}
+
+export default useSessionTimeout;

--- a/tests/hooks/useSessionTimeout.test.tsx
+++ b/tests/hooks/useSessionTimeout.test.tsx
@@ -1,0 +1,43 @@
+import { renderHook, act } from '@testing-library/react';
+import useSessionTimeout from '../../src/hooks/use-session-timeout';
+
+describe('Hook: useSessionTimeout', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  test('deve executar onTimeout após o período de inatividade', () => {
+    const onTimeout = jest.fn();
+    renderHook(() => useSessionTimeout(onTimeout, 1000));
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(onTimeout).toHaveBeenCalled();
+  });
+
+  test('deve reiniciar o timer quando há atividade do usuário', () => {
+    const onTimeout = jest.fn();
+    renderHook(() => useSessionTimeout(onTimeout, 1000));
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+      window.dispatchEvent(new Event('mousemove'));
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(onTimeout).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(onTimeout).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add hook `useSessionTimeout` to detect inactivity and fire a callback
- provide unit tests covering the timeout and reset behavior

## Testing
- `npx jest tests/hooks/useSessionTimeout.test.tsx` *(fails: SyntaxError Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_684b7209e3b48324a2a8287b377f1ebe