### PR TITLE
Implement isABCCardData type guard

### DIFF
--- a/src/types/clinicalTypes.ts
+++ b/src/types/clinicalTypes.ts
@@ -1,0 +1,23 @@
+export interface ABCCardData {
+  id: string;
+  patientId: string;
+  date: string; // ISO 8601
+  antecedent: string;
+  behavior: string;
+  consequence: string;
+  intensity?: number;
+}
+
+export function isABCCardData(data: unknown): data is ABCCardData {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'id' in data && typeof (data as any).id === 'string' &&
+    'patientId' in data && typeof (data as any).patientId === 'string' &&
+    'date' in data && typeof (data as any).date === 'string' &&
+    'antecedent' in data && typeof (data as any).antecedent === 'string' &&
+    'behavior' in data && typeof (data as any).behavior === 'string' &&
+    'consequence' in data && typeof (data as any).consequence === 'string' &&
+    ( !("intensity" in data) || typeof (data as any).intensity === 'number')
+  );
+}


### PR DESCRIPTION
## Summary
- add `ABCCardData` interface and `isABCCardData` type guard in `clinicalTypes.ts`

## Testing
- `npm run typecheck` *(fails: Cannot find name 'expect' and others)*
- `npm test` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_68539d11492c8324860952fda204952c